### PR TITLE
refactor(css): parametrize full colour palette

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -7,22 +7,47 @@
 }
 
 :root {
-    --primary-color: #6366f1;
-    --primary-dark: #4f46e5;
+    /* =============================================
+       PALETTE TOKENS
+       To add an alternate theme: override these in
+       [data-palette="alt"] on <html> (stub at end).
+       ============================================= */
+
+    /* Core brand colours */
+    --primary-color:   #6366f1;
+    --primary-dark:    #4f46e5;
     --secondary-color: #8b5cf6;
-    --accent-color: #f0abfc;
+    --accent-color:    #f0abfc;
+
+    /* RGB channels — lets every rgba() tint track the active palette */
+    --primary-rgb:    99, 102, 241;
+    --secondary-rgb: 139,  92, 246;
+    --accent-rgb:    236,  72, 153;
+    --mid-rgb:       168,  85, 247;   /* purple mid-stop */
+    --edu-start-rgb:  59, 130, 246;   /* blue used in education section */
+
+    /* Named gradients — derived from palette tokens */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+
+    /* ── Not palette-specific ── */
     --text-primary: #0f172a;
     --text-secondary: #475569;
     --text-light: #94a3b8;
     --bg-primary: #ffffff;
     --bg-secondary: #f8fafc;
     --bg-dark: #0f172a;
-    --gradient: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-    --gradient-warm: linear-gradient(135deg, #6366f1 0%, #a855f7 50%, #ec4899 100%);
     --shadow-sm: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
-    --shadow: 0 4px 16px rgba(99, 102, 241, 0.10), 0 1px 4px rgba(0,0,0,0.06);
-    --shadow-hover: 0 12px 36px rgba(99, 102, 241, 0.22), 0 4px 12px rgba(0,0,0,0.08);
-    --shadow-card: 0 2px 8px rgba(0,0,0,0.06), 0 0 0 1px rgba(99,102,241,0.06);
+    --shadow: 0 4px 16px rgba(var(--primary-rgb), 0.10), 0 1px 4px rgba(0,0,0,0.06);
+    --shadow-hover: 0 12px 36px rgba(var(--primary-rgb), 0.22), 0 4px 12px rgba(0,0,0,0.08);
+    --shadow-card: 0 2px 8px rgba(0,0,0,0.06), 0 0 0 1px rgba(var(--primary-rgb), 0.06);
     --radius-sm: 8px;
     --radius: 14px;
     --radius-lg: 20px;
@@ -52,7 +77,7 @@ html {
     background: rgba(255, 255, 255, 0.85);
     backdrop-filter: blur(20px) saturate(180%);
     -webkit-backdrop-filter: blur(20px) saturate(180%);
-    border-bottom: 1px solid rgba(99, 102, 241, 0.08);
+    border-bottom: 1px solid rgba(var(--primary-rgb), 0.08);
     z-index: 1000;
     padding: 1rem 0;
     transition: background var(--transition), box-shadow var(--transition);
@@ -97,7 +122,7 @@ html {
 .nav-links a:hover,
 .nav-links a.active {
     color: var(--primary-color);
-    background: rgba(99, 102, 241, 0.07);
+    background: rgba(var(--primary-rgb), 0.07);
 }
 
 .nav-links a::after {
@@ -144,7 +169,7 @@ html {
     inset: 0;
     background:
         radial-gradient(ellipse 80% 50% at 50% -20%, rgba(255,255,255,0.18) 0%, transparent 60%),
-        radial-gradient(ellipse 40% 40% at 80% 80%, rgba(236,72,153,0.25) 0%, transparent 60%),
+        radial-gradient(ellipse 40% 40% at 80% 80%, rgba(var(--accent-rgb),0.25) 0%, transparent 60%),
         repeating-linear-gradient(45deg,
             rgba(255,255,255,0.04) 0px,
             rgba(255,255,255,0.04) 1px,
@@ -309,7 +334,7 @@ section {
     box-shadow: var(--shadow-card);
     transition: transform var(--transition), box-shadow var(--transition);
     text-align: center;
-    border: 1px solid rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(var(--primary-rgb), 0.08);
     position: relative;
     overflow: hidden;
     aspect-ratio: 1 / 1;
@@ -378,7 +403,7 @@ section {
     top: 0;
     bottom: 0;
     width: 2px;
-    background: linear-gradient(180deg, #6366f1 0%, #a855f7 50%, #ec4899 100%);
+    background: var(--gradient-timeline);
     transform: translateX(-50%);
     border-radius: 2px;
 }
@@ -393,7 +418,7 @@ section {
     padding: 2rem;
     border-radius: var(--radius);
     box-shadow: var(--shadow-card);
-    border: 1px solid rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(var(--primary-rgb), 0.08);
     width: calc(50% - 20px);
     position: relative;
     transition: transform var(--transition), box-shadow var(--transition);
@@ -418,17 +443,17 @@ section {
     top: 2rem;
     width: 18px;
     height: 18px;
-    background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+    background: var(--gradient-dot);
     border-radius: 50%;
     transform: translateX(-50%);
     z-index: 1;
     border: 3px solid white;
-    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18);
+    box-shadow: 0 0 0 4px rgba(var(--primary-rgb), 0.18);
 }
 
 .timeline-date {
     padding: 0.4rem 1rem;
-    background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+    background: var(--gradient-dot);
     color: white;
     border-radius: var(--radius-full);
     font-size: 0.8rem;
@@ -469,7 +494,7 @@ section {
     border-radius: var(--radius-lg);
     overflow: hidden;
     box-shadow: var(--shadow-card);
-    border: 1px solid rgba(99, 102, 241, 0.07);
+    border: 1px solid rgba(var(--primary-rgb), 0.07);
     transition: transform var(--transition), box-shadow var(--transition);
     display: flex;
     flex-direction: column;
@@ -707,7 +732,7 @@ section {
 
 .submit-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(99, 102, 241, 0.4);
+    box-shadow: 0 8px 20px rgba(var(--primary-rgb), 0.4);
 }
 
 .submit-btn:active {
@@ -790,7 +815,7 @@ section {
     opacity: 0;
     visibility: hidden;
     z-index: 999;
-    box-shadow: 0 4px 14px rgba(99, 102, 241, 0.35);
+    box-shadow: 0 4px 14px rgba(var(--primary-rgb), 0.35);
 }
 
 .back-to-top.visible {
@@ -800,7 +825,7 @@ section {
 
 .back-to-top:hover {
     transform: translateY(-3px);
-    box-shadow: 0 8px 20px rgba(99, 102, 241, 0.5);
+    box-shadow: 0 8px 20px rgba(var(--primary-rgb), 0.5);
 }
 
 /* Loading indicator */
@@ -993,7 +1018,7 @@ section {
     top: 0;
     bottom: 0;
     width: 3px;
-    background: linear-gradient(180deg, #3b82f6 0%, #8b5cf6 50%, #ec4899 100%);
+    background: var(--gradient-edu-line);
     border-radius: 2px;
 }
 
@@ -1010,10 +1035,10 @@ section {
     top: 30px;
     width: 20px;
     height: 20px;
-    background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+    background: var(--gradient-edu-dot);
     border-radius: 50%;
     border: 4px solid #f8fafc;
-    box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.2);
+    box-shadow: 0 0 0 3px rgba(var(--secondary-rgb), 0.2);
     z-index: 2;
 }
 
@@ -1022,7 +1047,7 @@ section {
     border-radius: 16px;
     padding: 2rem;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border-left: 4px solid #8b5cf6;
+    border-left: 4px solid var(--secondary-color);
     transition: all 0.3s ease;
     position: relative;
 }
@@ -1051,13 +1076,13 @@ section {
 .institution {
     font-size: 1.1rem;
     font-weight: 600;
-    color: #8b5cf6;
+    color: var(--secondary-color);
     margin: 0;
 }
 
 .education-period {
     padding: 0.5rem 1.25rem;
-    background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+    background: var(--gradient-edu-dot);
     color: white;
     border-radius: 50px;
     font-size: 0.875rem;
@@ -1344,7 +1369,7 @@ a.logo { text-decoration: none; }
    ============================================= */
 .theme-toggle {
     background: none;
-    border: 1px solid rgba(99, 102, 241, 0.2);
+    border: 1px solid rgba(var(--primary-rgb), 0.2);
     border-radius: var(--radius-sm);
     width: 34px; height: 34px;
     display: flex; align-items: center; justify-content: center;
@@ -1354,8 +1379,8 @@ a.logo { text-decoration: none; }
     line-height: 1; flex-shrink: 0;
 }
 .theme-toggle:hover {
-    background: rgba(99, 102, 241, 0.08);
-    border-color: rgba(99, 102, 241, 0.4);
+    background: rgba(var(--primary-rgb), 0.08);
+    border-color: rgba(var(--primary-rgb), 0.4);
     transform: rotate(15deg);
 }
 
@@ -1374,7 +1399,7 @@ a.logo { text-decoration: none; }
     content: '';
     display: block;
     width: 32px; height: 32px;
-    border: 3px solid rgba(99, 102, 241, 0.12);
+    border: 3px solid rgba(var(--primary-rgb), 0.12);
     border-top-color: var(--primary-color);
     border-radius: 50%;
     animation: spin 0.7s linear infinite;
@@ -1454,7 +1479,7 @@ a.logo { text-decoration: none; }
     transition: background var(--transition), color var(--transition), transform var(--transition);
     border: 1px solid rgba(255,255,255,0.08);
 }
-.footer-social-link:hover { background: rgba(99,102,241,0.28); color: white; transform: translateY(-2px); }
+.footer-social-link:hover { background: rgba(var(--primary-rgb),0.28); color: white; transform: translateY(-2px); }
 .footer-social-link svg { flex-shrink: 0; }
 
 /* =============================================
@@ -1494,11 +1519,11 @@ a.logo { text-decoration: none; }
         transparent 1px, transparent 20px);
     pointer-events: none; z-index: 0;
 }
-.blog-image--1 { background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%); }
-.blog-image--2 { background: linear-gradient(135deg, #0ea5e9 0%, #6366f1 100%); }
+.blog-image--1 { background: var(--gradient-blog-1); }
+.blog-image--2 { background: var(--gradient-blog-2); }
 .blog-image--3 { background: linear-gradient(135deg, #10b981 0%, #059669 100%); }
 .blog-image--4 { background: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%); }
-.blog-image--5 { background: linear-gradient(135deg, #ec4899 0%, #8b5cf6 100%); }
+.blog-image--5 { background: var(--gradient-blog-5); }
 .blog-image--6 { background: linear-gradient(135deg, #06b6d4 0%, #0284c7 100%); }
 
 /* =============================================
@@ -1511,9 +1536,9 @@ a.logo { text-decoration: none; }
     --bg-primary: #0f172a;
     --bg-secondary: #1e293b;
     --bg-dark: #020617;
-    --shadow-card: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 1px rgba(99,102,241,0.15);
+    --shadow-card: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 1px rgba(var(--primary-rgb),0.15);
     --shadow: 0 4px 16px rgba(0,0,0,0.4);
-    --shadow-hover: 0 12px 36px rgba(99,102,241,0.35), 0 4px 12px rgba(0,0,0,0.4);
+    --shadow-hover: 0 12px 36px rgba(var(--primary-rgb),0.35), 0 4px 12px rgba(0,0,0,0.4);
 }
 body, .navbar, .skill-card, .timeline-content, .blog-card,
 .education-content, .loading, .footer {
@@ -1521,27 +1546,27 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
                 border-color 0.3s ease, box-shadow 0.3s ease;
 }
 [data-theme="dark"] body { background: var(--bg-primary); color: var(--text-primary); }
-[data-theme="dark"] .navbar { background: rgba(15,23,42,0.88) !important; border-bottom-color: rgba(99,102,241,0.15); }
+[data-theme="dark"] .navbar { background: rgba(15,23,42,0.88) !important; border-bottom-color: rgba(var(--primary-rgb),0.15); }
 [data-theme="dark"] .navbar.scrolled { background: rgba(15,23,42,0.98) !important; box-shadow: 0 2px 20px rgba(0,0,0,0.3) !important; }
 [data-theme="dark"] .nav-links a { color: var(--text-secondary); }
 [data-theme="dark"] .nav-links a:hover,
-[data-theme="dark"] .nav-links a.active { color: var(--primary-color); background: rgba(99,102,241,0.12); }
-[data-theme="dark"] .theme-toggle { border-color: rgba(99,102,241,0.25); color: var(--text-secondary); }
+[data-theme="dark"] .nav-links a.active { color: var(--primary-color); background: rgba(var(--primary-rgb),0.12); }
+[data-theme="dark"] .theme-toggle { border-color: rgba(var(--primary-rgb),0.25); color: var(--text-secondary); }
 [data-theme="dark"] .about { background: var(--bg-secondary); }
-[data-theme="dark"] .skill-card { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .skill-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .skill-card p { color: var(--text-secondary); }
 [data-theme="dark"] .about-text { color: var(--text-secondary); }
-[data-theme="dark"] .timeline-content { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .timeline-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .timeline-title { color: var(--text-primary); }
-[data-theme="dark"] .blog-card { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .blog-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .blog-title { color: var(--text-primary); }
 [data-theme="dark"] .blog-excerpt { color: var(--text-secondary); }
 [data-theme="dark"] .blog-meta { border-top-color: rgba(255,255,255,0.07); color: var(--text-light); }
 [data-theme="dark"] .education-section { background: var(--bg-secondary); }
-[data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .education-info h3 { color: var(--text-primary); }
 [data-theme="dark"] .institution { color: var(--secondary-color); }
-[data-theme="dark"] .highlight-item { background: rgba(99,102,241,0.1); color: var(--text-secondary); }
+[data-theme="dark"] .highlight-item { background: rgba(var(--primary-rgb),0.1); color: var(--text-secondary); }
 [data-theme="dark"] .detail-item { color: var(--text-secondary); }
 [data-theme="dark"] .section-title { color: var(--text-primary); }
 [data-theme="dark"] .loading { background: var(--bg-primary); }
@@ -1550,3 +1575,35 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
 [data-theme="dark"] .smooth-scroll-page section#experience { background: var(--bg-primary)   !important; }
 [data-theme="dark"] .smooth-scroll-page section#education  { background: var(--bg-secondary) !important; }
 [data-theme="dark"] .smooth-scroll-page section#blog       { background: var(--bg-secondary) !important; }
+
+/* =============================================
+   ALTERNATE PALETTE
+   Add  data-palette="alt"  to <html> to activate.
+   Replace the indigo values below with your colours.
+   All gradients auto-derive from the tokens above them.
+   ============================================= */
+[data-palette="alt"] {
+    /* Core brand colours */
+    --primary-color:   #6366f1;   /* ← your primary hex */
+    --primary-dark:    #4f46e5;
+    --secondary-color: #8b5cf6;
+    --accent-color:    #f0abfc;
+
+    /* RGB channels — must match the hex values above (R, G, B) */
+    --primary-rgb:    99, 102, 241;
+    --secondary-rgb: 139,  92, 246;
+    --accent-rgb:    236,  72, 153;
+    --mid-rgb:       168,  85, 247;
+    --edu-start-rgb:  59, 130, 246;
+
+    /* Gradients auto-derive — only override if you want a custom direction/stops */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+}


### PR DESCRIPTION
## What this does

Every hardcoded brand colour in `style.css` has been replaced with CSS custom-property tokens. Switching to an entirely different colour scheme now requires changing **5 hex values + 5 RGB channel tuples** in a single `[data-palette="alt"]` block at the bottom of the file.

## New tokens in `:root`

| Variable | Value | Used for |
|---|---|---|
| `--primary-rgb` | `99, 102, 241` | All `rgba()` tints of the primary colour |
| `--secondary-rgb` | `139, 92, 246` | Secondary `rgba()` tints |
| `--accent-rgb` | `236, 72, 153` | Pink accent tints |
| `--mid-rgb` | `168, 85, 247` | Gradient mid-stops |
| `--edu-start-rgb` | `59, 130, 246` | Blue start in education section |
| `--gradient-timeline` | derived | Timeline vertical line |
| `--gradient-dot` | derived | Timeline dots + date badges |
| `--gradient-edu-line` | derived | Education vertical line |
| `--gradient-edu-dot` | derived | Education dots + period badges |
| `--gradient-blog-1/2/5` | derived | Blog card backgrounds |

## How to activate the alt palette

1. Fill in your colours in the `[data-palette="alt"]` block at the bottom of `style.css`
2. Add `data-palette="alt"` to the `<html>` element — or toggle it with a JS one-liner

## Zero visual change

All tokens are initialised to the current indigo values, so this PR is a pure refactor. Nothing changes visually until new colours are filled in.