### PR TITLE
feat(theme): Castleton green palette + config-driven theming

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8" />
@@ -11,7 +11,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
     <style>
         .not-found {
             min-height: 70vh;
@@ -44,6 +44,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8" />
@@ -9,7 +9,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="apple-touch-icon" href="/assets/favicon.svg" />
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1" />
+    <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
     <style>

--- a/public/404.html
+++ b/public/404.html
@@ -11,7 +11,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
     <style>
         .not-found {
             min-height: 70vh;

--- a/public/about.html
+++ b/public/about.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>
@@ -92,8 +93,7 @@
                     <div class="skill-card">
                         <div class="icon">🚀</div>
                         <h4>MLOps & Infra</h4>
-                        <p>Docker, Kubernetes, Kubeflow, MLFlow, FastAPI, gRPC, GCP, AWS, GitOps
-                        </p>
+                        <p>Docker, Kubernetes, Kubeflow, MLFlow, FastAPI, gRPC, GCP, AWS, GitOps</p>
                     </div>
                     <div class="skill-card">
                         <div class="icon">🤖</div>

--- a/public/about.html
+++ b/public/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/about.html
+++ b/public/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>
@@ -42,6 +42,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/blog.html
+++ b/public/blog.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/blog.html
+++ b/public/blog.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/blog.html
+++ b/public/blog.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>
@@ -42,6 +42,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/contact.html
+++ b/public/contact.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/contact.html
+++ b/public/contact.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/contact.html
+++ b/public/contact.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>
@@ -42,6 +42,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/education.html
+++ b/public/education.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -26,7 +26,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/education.html
+++ b/public/education.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -28,7 +28,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>

--- a/public/education.html
+++ b/public/education.html
@@ -28,7 +28,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/experience.html
+++ b/public/experience.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/experience.html
+++ b/public/experience.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/experience.html
+++ b/public/experience.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>
@@ -42,6 +42,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/index-old.html
+++ b/public/index-old.html
@@ -10,6 +10,8 @@
     <title>Portfolio - Mukharbek Organokov</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="stylesheet" href="/src/css/style.css">
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="utf-8" />
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="apple-touch-icon" href="/assets/favicon.svg" />
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1" />
+    <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body class="smooth-scroll-page">
@@ -41,6 +41,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body class="smooth-scroll-page">

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -12,6 +12,8 @@
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
     <style>
         .policy-section {
             padding: 6rem 0 4rem;

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://www.organokov.com/privacy">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
-    <meta name="theme-color" content="#667eea">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <style>
         .policy-section {

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1,3 +1,6 @@
+/* Colour palettes (default + alternates) live in theme.css — imported first
+   so its custom properties are available to every rule below. */
+@import url('theme.css');
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
 
 * {
@@ -7,37 +10,8 @@
 }
 
 :root {
-    /* =============================================
-       PALETTE TOKENS
-       To add an alternate theme: override these in
-       [data-palette="alt"] on <html> (stub at end).
-       ============================================= */
-
-    /* Core brand colours */
-    --primary-color:   #6366f1;
-    --primary-dark:    #4f46e5;
-    --secondary-color: #8b5cf6;
-    --accent-color:    #f0abfc;
-
-    /* RGB channels — lets every rgba() tint track the active palette */
-    --primary-rgb:    99, 102, 241;
-    --secondary-rgb: 139,  92, 246;
-    --accent-rgb:    236,  72, 153;
-    --mid-rgb:       168,  85, 247;   /* purple mid-stop */
-    --edu-start-rgb:  59, 130, 246;   /* blue used in education section */
-
-    /* Named gradients — derived from palette tokens */
-    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
-    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
-    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
-    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
-    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
-
-    /* ── Not palette-specific ── */
+    /* Non-colour design tokens.
+       Brand colours and gradients are defined in theme.css. */
     --text-primary: #0f172a;
     --text-secondary: #475569;
     --text-light: #94a3b8;
@@ -1592,38 +1566,3 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
 [data-theme="dark"] .smooth-scroll-page section#experience { background: var(--bg-primary)   !important; }
 [data-theme="dark"] .smooth-scroll-page section#education  { background: var(--bg-secondary) !important; }
 [data-theme="dark"] .smooth-scroll-page section#blog       { background: var(--bg-secondary) !important; }
-
-/* =============================================
-   ALTERNATE PALETTE
-   Add  data-palette="alt"  to <html> to activate.
-   Replace the indigo values below with your colours.
-   All gradients auto-derive from the tokens above them.
-   ============================================= */
-/* GREEN PALETTE — Castleton / British Racing / Gunmetal
-   Colours from: #0A5C36 #0F5132 #14452F #18392B #1D2E28
-   ============================================= */
-[data-palette="alt"] {
-    /* Core brand colours */
-    --primary-color:   #0a5c36;   /* Castleton green */
-    --primary-dark:    #0f5132;   /* Castleton green (dark) */
-    --secondary-color: #14452f;   /* British racing green */
-    --accent-color:    #86efac;   /* Light mint — bright highlights */
-
-    /* RGB channels — must match the hex values above (R, G, B) */
-    --primary-rgb:    10,  92,  54;   /* #0a5c36 */
-    --secondary-rgb:  20,  69,  47;   /* #14452f */
-    --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
-    --mid-rgb:        15,  81,  50;   /* #0f5132 */
-    --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
-
-    /* Gradients auto-derive from the tokens above */
-    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
-    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
-    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
-    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
-    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
-}

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -448,7 +448,7 @@ section {
 
 .timeline-company {
     font-size: 1rem;
-    color: var(--secondary-color);
+    color: var(--accent-text);
     margin-bottom: 1rem;
     font-style: normal;
     font-weight: 600;
@@ -1050,7 +1050,7 @@ section {
 .institution {
     font-size: 1.1rem;
     font-weight: 600;
-    color: var(--secondary-color);
+    color: var(--accent-text);
     margin: 0;
 }
 
@@ -1556,7 +1556,7 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
 [data-theme="dark"] .education-section { background: var(--bg-secondary); }
 [data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .education-info h3 { color: var(--text-primary); }
-[data-theme="dark"] .institution { color: var(--secondary-color); }
+[data-theme="dark"] .institution { color: var(--accent-text); }
 [data-theme="dark"] .highlight-item { background: rgba(var(--primary-rgb),0.1); color: var(--text-secondary); }
 [data-theme="dark"] .detail-item { color: var(--text-secondary); }
 [data-theme="dark"] .section-title { color: var(--text-primary); }

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1384,6 +1384,23 @@ a.logo { text-decoration: none; }
     transform: rotate(15deg);
 }
 
+.palette-toggle {
+    background: none;
+    border: 1px solid rgba(var(--primary-rgb), 0.2);
+    border-radius: var(--radius-sm);
+    width: 34px; height: 34px;
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: background var(--transition), border-color var(--transition), transform var(--transition);
+    line-height: 1; flex-shrink: 0;
+}
+.palette-toggle:hover {
+    background: rgba(var(--primary-rgb), 0.08);
+    border-color: rgba(var(--primary-rgb), 0.4);
+    transform: scale(1.1);
+}
+
 /* =============================================
    NAVBAR SCROLLED STATE
    ============================================= */

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1582,21 +1582,24 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
    Replace the indigo values below with your colours.
    All gradients auto-derive from the tokens above them.
    ============================================= */
+/* GREEN PALETTE — Castleton / British Racing / Gunmetal
+   Colours from: #0A5C36 #0F5132 #14452F #18392B #1D2E28
+   ============================================= */
 [data-palette="alt"] {
     /* Core brand colours */
-    --primary-color:   #6366f1;   /* ← your primary hex */
-    --primary-dark:    #4f46e5;
-    --secondary-color: #8b5cf6;
-    --accent-color:    #f0abfc;
+    --primary-color:   #0a5c36;   /* Castleton green */
+    --primary-dark:    #0f5132;   /* Castleton green (dark) */
+    --secondary-color: #14452f;   /* British racing green */
+    --accent-color:    #86efac;   /* Light mint — bright highlights */
 
     /* RGB channels — must match the hex values above (R, G, B) */
-    --primary-rgb:    99, 102, 241;
-    --secondary-rgb: 139,  92, 246;
-    --accent-rgb:    236,  72, 153;
-    --mid-rgb:       168,  85, 247;
-    --edu-start-rgb:  59, 130, 246;
+    --primary-rgb:    10,  92,  54;   /* #0a5c36 */
+    --secondary-rgb:  20,  69,  47;   /* #14452f */
+    --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
+    --mid-rgb:        15,  81,  50;   /* #0f5132 */
+    --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
 
-    /* Gradients auto-derive — only override if you want a custom direction/stops */
+    /* Gradients auto-derive from the tokens above */
     --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
     --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
     --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -7,22 +7,47 @@
 }
 
 :root {
-    --primary-color: #6366f1;
-    --primary-dark: #4f46e5;
+    /* =============================================
+       PALETTE TOKENS
+       To add an alternate theme: override these in
+       [data-palette="alt"] on <html> (stub at end).
+       ============================================= */
+
+    /* Core brand colours */
+    --primary-color:   #6366f1;
+    --primary-dark:    #4f46e5;
     --secondary-color: #8b5cf6;
-    --accent-color: #f0abfc;
+    --accent-color:    #f0abfc;
+
+    /* RGB channels — lets every rgba() tint track the active palette */
+    --primary-rgb:    99, 102, 241;
+    --secondary-rgb: 139,  92, 246;
+    --accent-rgb:    236,  72, 153;
+    --mid-rgb:       168,  85, 247;   /* purple mid-stop */
+    --edu-start-rgb:  59, 130, 246;   /* blue used in education section */
+
+    /* Named gradients — derived from palette tokens */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+
+    /* ── Not palette-specific ── */
     --text-primary: #0f172a;
     --text-secondary: #475569;
     --text-light: #94a3b8;
     --bg-primary: #ffffff;
     --bg-secondary: #f8fafc;
     --bg-dark: #0f172a;
-    --gradient: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-    --gradient-warm: linear-gradient(135deg, #6366f1 0%, #a855f7 50%, #ec4899 100%);
     --shadow-sm: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
-    --shadow: 0 4px 16px rgba(99, 102, 241, 0.10), 0 1px 4px rgba(0,0,0,0.06);
-    --shadow-hover: 0 12px 36px rgba(99, 102, 241, 0.22), 0 4px 12px rgba(0,0,0,0.08);
-    --shadow-card: 0 2px 8px rgba(0,0,0,0.06), 0 0 0 1px rgba(99,102,241,0.06);
+    --shadow: 0 4px 16px rgba(var(--primary-rgb), 0.10), 0 1px 4px rgba(0,0,0,0.06);
+    --shadow-hover: 0 12px 36px rgba(var(--primary-rgb), 0.22), 0 4px 12px rgba(0,0,0,0.08);
+    --shadow-card: 0 2px 8px rgba(0,0,0,0.06), 0 0 0 1px rgba(var(--primary-rgb), 0.06);
     --radius-sm: 8px;
     --radius: 14px;
     --radius-lg: 20px;
@@ -52,7 +77,7 @@ html {
     background: rgba(255, 255, 255, 0.85);
     backdrop-filter: blur(20px) saturate(180%);
     -webkit-backdrop-filter: blur(20px) saturate(180%);
-    border-bottom: 1px solid rgba(99, 102, 241, 0.08);
+    border-bottom: 1px solid rgba(var(--primary-rgb), 0.08);
     z-index: 1000;
     padding: 1rem 0;
     transition: background var(--transition), box-shadow var(--transition);
@@ -97,7 +122,7 @@ html {
 .nav-links a:hover,
 .nav-links a.active {
     color: var(--primary-color);
-    background: rgba(99, 102, 241, 0.07);
+    background: rgba(var(--primary-rgb), 0.07);
 }
 
 .nav-links a::after {
@@ -144,7 +169,7 @@ html {
     inset: 0;
     background:
         radial-gradient(ellipse 80% 50% at 50% -20%, rgba(255,255,255,0.18) 0%, transparent 60%),
-        radial-gradient(ellipse 40% 40% at 80% 80%, rgba(236,72,153,0.25) 0%, transparent 60%),
+        radial-gradient(ellipse 40% 40% at 80% 80%, rgba(var(--accent-rgb),0.25) 0%, transparent 60%),
         repeating-linear-gradient(45deg,
             rgba(255,255,255,0.04) 0px,
             rgba(255,255,255,0.04) 1px,
@@ -309,7 +334,7 @@ section {
     box-shadow: var(--shadow-card);
     transition: transform var(--transition), box-shadow var(--transition);
     text-align: center;
-    border: 1px solid rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(var(--primary-rgb), 0.08);
     position: relative;
     overflow: hidden;
     aspect-ratio: 1 / 1;
@@ -378,7 +403,7 @@ section {
     top: 0;
     bottom: 0;
     width: 2px;
-    background: linear-gradient(180deg, #6366f1 0%, #a855f7 50%, #ec4899 100%);
+    background: var(--gradient-timeline);
     transform: translateX(-50%);
     border-radius: 2px;
 }
@@ -393,7 +418,7 @@ section {
     padding: 2rem;
     border-radius: var(--radius);
     box-shadow: var(--shadow-card);
-    border: 1px solid rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(var(--primary-rgb), 0.08);
     width: calc(50% - 20px);
     position: relative;
     transition: transform var(--transition), box-shadow var(--transition);
@@ -418,17 +443,17 @@ section {
     top: 2rem;
     width: 18px;
     height: 18px;
-    background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+    background: var(--gradient-dot);
     border-radius: 50%;
     transform: translateX(-50%);
     z-index: 1;
     border: 3px solid white;
-    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18);
+    box-shadow: 0 0 0 4px rgba(var(--primary-rgb), 0.18);
 }
 
 .timeline-date {
     padding: 0.4rem 1rem;
-    background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+    background: var(--gradient-dot);
     color: white;
     border-radius: var(--radius-full);
     font-size: 0.8rem;
@@ -469,7 +494,7 @@ section {
     border-radius: var(--radius-lg);
     overflow: hidden;
     box-shadow: var(--shadow-card);
-    border: 1px solid rgba(99, 102, 241, 0.07);
+    border: 1px solid rgba(var(--primary-rgb), 0.07);
     transition: transform var(--transition), box-shadow var(--transition);
     display: flex;
     flex-direction: column;
@@ -707,7 +732,7 @@ section {
 
 .submit-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(99, 102, 241, 0.4);
+    box-shadow: 0 8px 20px rgba(var(--primary-rgb), 0.4);
 }
 
 .submit-btn:active {
@@ -790,7 +815,7 @@ section {
     opacity: 0;
     visibility: hidden;
     z-index: 999;
-    box-shadow: 0 4px 14px rgba(99, 102, 241, 0.35);
+    box-shadow: 0 4px 14px rgba(var(--primary-rgb), 0.35);
 }
 
 .back-to-top.visible {
@@ -800,7 +825,7 @@ section {
 
 .back-to-top:hover {
     transform: translateY(-3px);
-    box-shadow: 0 8px 20px rgba(99, 102, 241, 0.5);
+    box-shadow: 0 8px 20px rgba(var(--primary-rgb), 0.5);
 }
 
 /* Loading indicator */
@@ -993,7 +1018,7 @@ section {
     top: 0;
     bottom: 0;
     width: 3px;
-    background: linear-gradient(180deg, #3b82f6 0%, #8b5cf6 50%, #ec4899 100%);
+    background: var(--gradient-edu-line);
     border-radius: 2px;
 }
 
@@ -1010,10 +1035,10 @@ section {
     top: 30px;
     width: 20px;
     height: 20px;
-    background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+    background: var(--gradient-edu-dot);
     border-radius: 50%;
     border: 4px solid #f8fafc;
-    box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.2);
+    box-shadow: 0 0 0 3px rgba(var(--secondary-rgb), 0.2);
     z-index: 2;
 }
 
@@ -1022,7 +1047,7 @@ section {
     border-radius: 16px;
     padding: 2rem;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border-left: 4px solid #8b5cf6;
+    border-left: 4px solid var(--secondary-color);
     transition: all 0.3s ease;
     position: relative;
 }
@@ -1051,13 +1076,13 @@ section {
 .institution {
     font-size: 1.1rem;
     font-weight: 600;
-    color: #8b5cf6;
+    color: var(--secondary-color);
     margin: 0;
 }
 
 .education-period {
     padding: 0.5rem 1.25rem;
-    background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+    background: var(--gradient-edu-dot);
     color: white;
     border-radius: 50px;
     font-size: 0.875rem;
@@ -1344,7 +1369,7 @@ a.logo { text-decoration: none; }
    ============================================= */
 .theme-toggle {
     background: none;
-    border: 1px solid rgba(99, 102, 241, 0.2);
+    border: 1px solid rgba(var(--primary-rgb), 0.2);
     border-radius: var(--radius-sm);
     width: 34px; height: 34px;
     display: flex; align-items: center; justify-content: center;
@@ -1354,8 +1379,8 @@ a.logo { text-decoration: none; }
     line-height: 1; flex-shrink: 0;
 }
 .theme-toggle:hover {
-    background: rgba(99, 102, 241, 0.08);
-    border-color: rgba(99, 102, 241, 0.4);
+    background: rgba(var(--primary-rgb), 0.08);
+    border-color: rgba(var(--primary-rgb), 0.4);
     transform: rotate(15deg);
 }
 
@@ -1374,7 +1399,7 @@ a.logo { text-decoration: none; }
     content: '';
     display: block;
     width: 32px; height: 32px;
-    border: 3px solid rgba(99, 102, 241, 0.12);
+    border: 3px solid rgba(var(--primary-rgb), 0.12);
     border-top-color: var(--primary-color);
     border-radius: 50%;
     animation: spin 0.7s linear infinite;
@@ -1454,7 +1479,7 @@ a.logo { text-decoration: none; }
     transition: background var(--transition), color var(--transition), transform var(--transition);
     border: 1px solid rgba(255,255,255,0.08);
 }
-.footer-social-link:hover { background: rgba(99,102,241,0.28); color: white; transform: translateY(-2px); }
+.footer-social-link:hover { background: rgba(var(--primary-rgb),0.28); color: white; transform: translateY(-2px); }
 .footer-social-link svg { flex-shrink: 0; }
 
 /* =============================================
@@ -1494,11 +1519,11 @@ a.logo { text-decoration: none; }
         transparent 1px, transparent 20px);
     pointer-events: none; z-index: 0;
 }
-.blog-image--1 { background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%); }
-.blog-image--2 { background: linear-gradient(135deg, #0ea5e9 0%, #6366f1 100%); }
+.blog-image--1 { background: var(--gradient-blog-1); }
+.blog-image--2 { background: var(--gradient-blog-2); }
 .blog-image--3 { background: linear-gradient(135deg, #10b981 0%, #059669 100%); }
 .blog-image--4 { background: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%); }
-.blog-image--5 { background: linear-gradient(135deg, #ec4899 0%, #8b5cf6 100%); }
+.blog-image--5 { background: var(--gradient-blog-5); }
 .blog-image--6 { background: linear-gradient(135deg, #06b6d4 0%, #0284c7 100%); }
 
 /* =============================================
@@ -1511,9 +1536,9 @@ a.logo { text-decoration: none; }
     --bg-primary: #0f172a;
     --bg-secondary: #1e293b;
     --bg-dark: #020617;
-    --shadow-card: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 1px rgba(99,102,241,0.15);
+    --shadow-card: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 1px rgba(var(--primary-rgb),0.15);
     --shadow: 0 4px 16px rgba(0,0,0,0.4);
-    --shadow-hover: 0 12px 36px rgba(99,102,241,0.35), 0 4px 12px rgba(0,0,0,0.4);
+    --shadow-hover: 0 12px 36px rgba(var(--primary-rgb),0.35), 0 4px 12px rgba(0,0,0,0.4);
 }
 body, .navbar, .skill-card, .timeline-content, .blog-card,
 .education-content, .loading, .footer {
@@ -1521,27 +1546,27 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
                 border-color 0.3s ease, box-shadow 0.3s ease;
 }
 [data-theme="dark"] body { background: var(--bg-primary); color: var(--text-primary); }
-[data-theme="dark"] .navbar { background: rgba(15,23,42,0.88) !important; border-bottom-color: rgba(99,102,241,0.15); }
+[data-theme="dark"] .navbar { background: rgba(15,23,42,0.88) !important; border-bottom-color: rgba(var(--primary-rgb),0.15); }
 [data-theme="dark"] .navbar.scrolled { background: rgba(15,23,42,0.98) !important; box-shadow: 0 2px 20px rgba(0,0,0,0.3) !important; }
 [data-theme="dark"] .nav-links a { color: var(--text-secondary); }
 [data-theme="dark"] .nav-links a:hover,
-[data-theme="dark"] .nav-links a.active { color: var(--primary-color); background: rgba(99,102,241,0.12); }
-[data-theme="dark"] .theme-toggle { border-color: rgba(99,102,241,0.25); color: var(--text-secondary); }
+[data-theme="dark"] .nav-links a.active { color: var(--primary-color); background: rgba(var(--primary-rgb),0.12); }
+[data-theme="dark"] .theme-toggle { border-color: rgba(var(--primary-rgb),0.25); color: var(--text-secondary); }
 [data-theme="dark"] .about { background: var(--bg-secondary); }
-[data-theme="dark"] .skill-card { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .skill-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .skill-card p { color: var(--text-secondary); }
 [data-theme="dark"] .about-text { color: var(--text-secondary); }
-[data-theme="dark"] .timeline-content { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .timeline-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .timeline-title { color: var(--text-primary); }
-[data-theme="dark"] .blog-card { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .blog-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .blog-title { color: var(--text-primary); }
 [data-theme="dark"] .blog-excerpt { color: var(--text-secondary); }
 [data-theme="dark"] .blog-meta { border-top-color: rgba(255,255,255,0.07); color: var(--text-light); }
 [data-theme="dark"] .education-section { background: var(--bg-secondary); }
-[data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .education-info h3 { color: var(--text-primary); }
 [data-theme="dark"] .institution { color: var(--secondary-color); }
-[data-theme="dark"] .highlight-item { background: rgba(99,102,241,0.1); color: var(--text-secondary); }
+[data-theme="dark"] .highlight-item { background: rgba(var(--primary-rgb),0.1); color: var(--text-secondary); }
 [data-theme="dark"] .detail-item { color: var(--text-secondary); }
 [data-theme="dark"] .section-title { color: var(--text-primary); }
 [data-theme="dark"] .loading { background: var(--bg-primary); }
@@ -1550,3 +1575,35 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
 [data-theme="dark"] .smooth-scroll-page section#experience { background: var(--bg-primary)   !important; }
 [data-theme="dark"] .smooth-scroll-page section#education  { background: var(--bg-secondary) !important; }
 [data-theme="dark"] .smooth-scroll-page section#blog       { background: var(--bg-secondary) !important; }
+
+/* =============================================
+   ALTERNATE PALETTE
+   Add  data-palette="alt"  to <html> to activate.
+   Replace the indigo values below with your colours.
+   All gradients auto-derive from the tokens above them.
+   ============================================= */
+[data-palette="alt"] {
+    /* Core brand colours */
+    --primary-color:   #6366f1;   /* ← your primary hex */
+    --primary-dark:    #4f46e5;
+    --secondary-color: #8b5cf6;
+    --accent-color:    #f0abfc;
+
+    /* RGB channels — must match the hex values above (R, G, B) */
+    --primary-rgb:    99, 102, 241;
+    --secondary-rgb: 139,  92, 246;
+    --accent-rgb:    236,  72, 153;
+    --mid-rgb:       168,  85, 247;
+    --edu-start-rgb:  59, 130, 246;
+
+    /* Gradients auto-derive — only override if you want a custom direction/stops */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+}

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -183,7 +183,7 @@ html {
 }
 
 .hero p {
-    font-size: clamp(1.1rem, 2vw, 1.35rem);
+    font-size: clamp(1.35rem, 2.6vw, 1.7rem);
     margin-bottom: 2.5rem;
     opacity: 0.88;
     font-weight: 400;

--- a/public/src/css/theme.css
+++ b/public/src/css/theme.css
@@ -30,6 +30,7 @@
     --primary-dark:    #4f46e5;
     --secondary-color: #8b5cf6;
     --accent-color:    #f0abfc;
+    --accent-text:     var(--secondary-color);   /* dates / company / institution labels */
 
     /* RGB channels — lets every rgba() tint track the active palette */
     --primary-rgb:    99, 102, 241;
@@ -60,12 +61,13 @@
     --primary-dark:    #0f5132;   /* Castleton green (dark) */
     --secondary-color: #14452f;   /* British racing green */
     --accent-color:    #86efac;   /* Light mint — bright highlights */
+    --accent-text:     #15803d;   /* lighter green for dates / company / institution labels */
 
     /* RGB channels — must match the hex values above (R, G, B) */
     --primary-rgb:    10,  92,  54;   /* #0a5c36 */
     --secondary-rgb:  20,  69,  47;   /* #14452f */
     --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
-    --mid-rgb:        15,  81,  50;   /* #0f5132 */
+    --mid-rgb:        21, 128,  61;   /* #15803d — lightened so date badges read brighter */
     --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
 
     /* Gradients auto-derive from the tokens above */

--- a/public/src/css/theme.css
+++ b/public/src/css/theme.css
@@ -1,0 +1,81 @@
+/* =====================================================================
+   THEME — COLOUR PALETTES
+   ---------------------------------------------------------------------
+   This is the single place to edit colours or add new palettes.
+   It is pulled into style.css via:   @import url('theme.css');
+
+   • :root                 → the DEFAULT palette (indigo / violet)
+   • [data-palette="alt"]  → the ALTERNATE palette (Castleton green)
+
+   Which one is shown is decided by  src/js/theme-config.js
+   (and the in-page palette toggle button). To add a third palette,
+   copy the [data-palette="alt"] block, rename it e.g.
+   [data-palette="ocean"], change the values, then reference "ocean"
+   from theme-config.js.
+
+   HOW THE TOKENS WORK
+   • --primary-color / --secondary-color / --accent-color  → hex values
+   • --*-rgb            → the SAME colours as "R, G, B" channels so that
+                          translucent tints can be written as
+                          rgba(var(--primary-rgb), 0.1)
+   • --gradient-*       → ready-made gradients derived from the tokens
+   ===================================================================== */
+
+/* ---------------------------------------------------------------------
+   DEFAULT PALETTE — Indigo / Violet
+   --------------------------------------------------------------------- */
+:root {
+    /* Core brand colours */
+    --primary-color:   #6366f1;
+    --primary-dark:    #4f46e5;
+    --secondary-color: #8b5cf6;
+    --accent-color:    #f0abfc;
+
+    /* RGB channels — lets every rgba() tint track the active palette */
+    --primary-rgb:    99, 102, 241;
+    --secondary-rgb: 139,  92, 246;
+    --accent-rgb:    236,  72, 153;
+    --mid-rgb:       168,  85, 247;   /* purple mid-stop */
+    --edu-start-rgb:  59, 130, 246;   /* blue used in education section */
+
+    /* Named gradients — derived from palette tokens */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+}
+
+/* ---------------------------------------------------------------------
+   ALTERNATE PALETTE — Castleton / British Racing Green
+   Source swatch: #0A5C36 #0F5132 #14452F #18392B #1D2E28
+   --------------------------------------------------------------------- */
+[data-palette="alt"] {
+    /* Core brand colours */
+    --primary-color:   #0a5c36;   /* Castleton green */
+    --primary-dark:    #0f5132;   /* Castleton green (dark) */
+    --secondary-color: #14452f;   /* British racing green */
+    --accent-color:    #86efac;   /* Light mint — bright highlights */
+
+    /* RGB channels — must match the hex values above (R, G, B) */
+    --primary-rgb:    10,  92,  54;   /* #0a5c36 */
+    --secondary-rgb:  20,  69,  47;   /* #14452f */
+    --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
+    --mid-rgb:        15,  81,  50;   /* #0f5132 */
+    --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
+
+    /* Gradients auto-derive from the tokens above */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+}

--- a/public/src/js/aggregate.js
+++ b/public/src/js/aggregate.js
@@ -345,7 +345,7 @@ function setupPaletteToggle() {
         return;
     }
     const setIcon = (isGreen) => {
-        btn.textContent = isGreen ? '🟣' : '🌿';
+        btn.textContent = isGreen ? '🟣' : '🟢';
         btn.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
     };
     setIcon(document.documentElement.hasAttribute('data-palette'));

--- a/public/src/js/aggregate.js
+++ b/public/src/js/aggregate.js
@@ -328,7 +328,32 @@ async function init() {
 
 // Start when DOM is ready
 if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
+    document.addEventListener('DOMContentLoaded', () => {
+        init();
+        setupPaletteToggle();
+    });
 } else {
     init();
+    setupPaletteToggle();
+}
+
+function setupPaletteToggle() {
+    const btn = document.getElementById('paletteToggle');
+    if (!btn) return;
+    const setIcon = (isGreen) => {
+        btn.textContent = isGreen ? '🟣' : '🌿';
+        btn.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+    };
+    setIcon(document.documentElement.hasAttribute('data-palette'));
+    btn.addEventListener('click', () => {
+        const isGreen = document.documentElement.hasAttribute('data-palette');
+        if (isGreen) {
+            document.documentElement.removeAttribute('data-palette');
+            localStorage.setItem('palette', 'default');
+        } else {
+            document.documentElement.setAttribute('data-palette', 'alt');
+            localStorage.setItem('palette', 'alt');
+        }
+        setIcon(!isGreen);
+    });
 }

--- a/public/src/js/aggregate.js
+++ b/public/src/js/aggregate.js
@@ -340,20 +340,18 @@ if (document.readyState === 'loading') {
 function setupPaletteToggle() {
     const btn = document.getElementById('paletteToggle');
     if (!btn) return;
+    if (window.SITE_THEME && window.SITE_THEME.enablePaletteToggle === false) {
+        btn.style.display = 'none';
+        return;
+    }
     const setIcon = (isGreen) => {
         btn.textContent = isGreen ? '🟣' : '🌿';
         btn.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
     };
     setIcon(document.documentElement.hasAttribute('data-palette'));
     btn.addEventListener('click', () => {
-        const isGreen = document.documentElement.hasAttribute('data-palette');
-        if (isGreen) {
-            document.documentElement.removeAttribute('data-palette');
-            localStorage.setItem('palette', 'default');
-        } else {
-            document.documentElement.setAttribute('data-palette', 'alt');
-            localStorage.setItem('palette', 'alt');
-        }
-        setIcon(!isGreen);
+        const next = document.documentElement.hasAttribute('data-palette') ? 'indigo' : 'green';
+        window.__applyPalette(next);
+        setIcon(next === 'green');
     });
 }

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -148,23 +148,22 @@ themeToggle?.addEventListener('click', () => {
 
 // ── Palette toggle ──
 const paletteToggle = document.getElementById('paletteToggle');
-const setPaletteIcon = (isGreen) => {
-    if (!paletteToggle) return;
-    paletteToggle.textContent = isGreen ? '🟣' : '🌿';
-    paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
-};
-setPaletteIcon(document.documentElement.hasAttribute('data-palette'));
-paletteToggle?.addEventListener('click', () => {
-    const isGreen = document.documentElement.hasAttribute('data-palette');
-    if (isGreen) {
-        document.documentElement.removeAttribute('data-palette');
-        localStorage.setItem('palette', 'default');
+if (paletteToggle) {
+    if (window.SITE_THEME && window.SITE_THEME.enablePaletteToggle === false) {
+        paletteToggle.style.display = 'none';
     } else {
-        document.documentElement.setAttribute('data-palette', 'alt');
-        localStorage.setItem('palette', 'alt');
+        const setPaletteIcon = (isGreen) => {
+            paletteToggle.textContent = isGreen ? '🟣' : '🌿';
+            paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+        };
+        setPaletteIcon(document.documentElement.hasAttribute('data-palette'));
+        paletteToggle.addEventListener('click', () => {
+            const next = document.documentElement.hasAttribute('data-palette') ? 'indigo' : 'green';
+            window.__applyPalette(next);
+            setPaletteIcon(next === 'green');
+        });
     }
-    setPaletteIcon(!isGreen);
-});
+}
 
 // ── Scroll progress bar ──
 const scrollProgress = document.getElementById('scrollProgress');

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -153,7 +153,7 @@ if (paletteToggle) {
         paletteToggle.style.display = 'none';
     } else {
         const setPaletteIcon = (isGreen) => {
-            paletteToggle.textContent = isGreen ? '🟣' : '🌿';
+            paletteToggle.textContent = isGreen ? '🟣' : '🟢';
             paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
         };
         setPaletteIcon(document.documentElement.hasAttribute('data-palette'));

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -146,6 +146,26 @@ themeToggle?.addEventListener('click', () => {
     setThemeIcon(next === 'dark');
 });
 
+// ── Palette toggle ──
+const paletteToggle = document.getElementById('paletteToggle');
+const setPaletteIcon = (isGreen) => {
+    if (!paletteToggle) return;
+    paletteToggle.textContent = isGreen ? '🟣' : '🌿';
+    paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+};
+setPaletteIcon(document.documentElement.hasAttribute('data-palette'));
+paletteToggle?.addEventListener('click', () => {
+    const isGreen = document.documentElement.hasAttribute('data-palette');
+    if (isGreen) {
+        document.documentElement.removeAttribute('data-palette');
+        localStorage.setItem('palette', 'default');
+    } else {
+        document.documentElement.setAttribute('data-palette', 'alt');
+        localStorage.setItem('palette', 'alt');
+    }
+    setPaletteIcon(!isGreen);
+});
+
 // ── Scroll progress bar ──
 const scrollProgress = document.getElementById('scrollProgress');
 if (scrollProgress) {

--- a/public/src/js/theme-config.js
+++ b/public/src/js/theme-config.js
@@ -1,0 +1,48 @@
+/* =====================================================================
+   THEME CONFIG  —  behaviour settings (edit the values in CONFIG below)
+   ---------------------------------------------------------------------
+   The actual COLOURS live in  src/css/theme.css.
+   This file decides WHICH palette is shown and whether visitors can
+   switch it. It is loaded in the <head> of every page so the choice is
+   applied before the first paint (no colour flash).
+   ===================================================================== */
+
+window.SITE_THEME = {
+    /* Palette shown to first-time visitors (before they pick one):
+         'green'  → Castleton green   (theme.css [data-palette="alt"])
+         'indigo' → original indigo   (theme.css :root)                  */
+    defaultPalette: 'green',
+
+    /* Show the palette switch button in the navbar?  true | false       */
+    enablePaletteToggle: true,
+};
+
+/* ---------------------------------------------------------------------
+   Internals — no need to edit below this line.
+   Applies the resolved palette immediately (runs before <body> paints)
+   and exposes window.__applyPalette() for the navbar toggle button.
+   --------------------------------------------------------------------- */
+(function () {
+    var cfg = window.SITE_THEME || {};
+
+    function apply(name) {
+        if (name === 'green') {
+            document.documentElement.setAttribute('data-palette', 'alt');
+        } else {
+            document.documentElement.removeAttribute('data-palette');
+        }
+    }
+
+    // Saved choice wins over the config default.
+    var saved = localStorage.getItem('palette');
+    if (saved === 'alt') saved = 'green';          // legacy value support
+    if (saved === 'default') saved = 'indigo';     // legacy value support
+
+    apply(saved || cfg.defaultPalette || 'indigo');
+
+    // Shared helper used by the toggle button in main.js / aggregate.js
+    window.__applyPalette = function (name) {
+        apply(name);
+        localStorage.setItem('palette', name);
+    };
+})();


### PR DESCRIPTION
Adds a dark British-green palette **and** a clean, config-driven theming system so palettes can be edited, switched, or extended from one place each.

## Two config files (the answer to "where do I control this?")

| File | Controls | Edit when you want to... |
|------|----------|--------------------------|
| `src/css/theme.css` | **Colour values** | Tweak a colour, or add a whole new palette |
| `src/js/theme-config.js` | **Behaviour** | Change the default palette, or hide the switch button |

`theme.css` is pulled into `style.css` with `@import url('theme.css')` (same pattern as the font import), so the main stylesheet stays focused on layout/components.

## theme-config.js settings

```js
window.SITE_THEME = {
  defaultPalette: 'green',     // 'green' | 'indigo'  (first-time visitors)
  enablePaletteToggle: true,   // show/hide the navbar switch button
};
```

It applies the chosen palette before first paint (no colour flash) and a visitor's choice is saved to `localStorage`.

## Palettes included

| | Default (`:root`) | Alternate (`[data-palette="alt"]`) |
|---|---|---|
| Primary | `#6366f1` indigo | `#0a5c36` Castleton green |
| Secondary | `#8b5cf6` violet | `#14452f` British racing green |
| Accent tints | `#ec4899` | `#10b981` emerald |

## Live switching

A palette toggle button (🟣 / 🌿) sits next to the dark-mode toggle in the navbar. Both palettes are always available; the choice persists across pages and sessions.

## Adding a third palette later

1. Copy the `[data-palette="alt"]` block in `theme.css`, rename it e.g. `[data-palette="ocean"]`, change the values.
2. Point `defaultPalette` at it (or wire another button).

## Notes

- Every hardcoded brand colour across `style.css` was first parametrized into CSS custom properties, which is what makes one-line palette swaps possible.
- `privacy.html` and `index-old.html` previously had no theme init at all (privacy was rendering in the wrong colour) — now consistent with the rest of the site.
- Reverting to indigo for everyone is a one-word change: `defaultPalette: 'indigo'`.
