### PR TITLE
feat(theme): multi-palette system with Castleton green + experimental palettes

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8" />
@@ -11,7 +11,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
     <style>
         .not-found {
             min-height: 70vh;
@@ -44,6 +44,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8" />
@@ -9,7 +9,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="apple-touch-icon" href="/assets/favicon.svg" />
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1" />
+    <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
     <style>

--- a/public/404.html
+++ b/public/404.html
@@ -11,7 +11,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
     <style>
         .not-found {
             min-height: 70vh;

--- a/public/about.html
+++ b/public/about.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>
@@ -92,8 +93,7 @@
                     <div class="skill-card">
                         <div class="icon">🚀</div>
                         <h4>MLOps & Infra</h4>
-                        <p>Docker, Kubernetes, Kubeflow, MLFlow, FastAPI, gRPC, GCP, AWS, GitOps
-                        </p>
+                        <p>Docker, Kubernetes, Kubeflow, MLFlow, FastAPI, gRPC, GCP, AWS, GitOps</p>
                     </div>
                     <div class="skill-card">
                         <div class="icon">🤖</div>

--- a/public/about.html
+++ b/public/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/about.html
+++ b/public/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>
@@ -42,6 +42,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/blog.html
+++ b/public/blog.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/blog.html
+++ b/public/blog.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/blog.html
+++ b/public/blog.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>
@@ -42,6 +42,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/contact.html
+++ b/public/contact.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/contact.html
+++ b/public/contact.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/contact.html
+++ b/public/contact.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>
@@ -42,6 +42,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/education.html
+++ b/public/education.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -26,7 +26,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/education.html
+++ b/public/education.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -28,7 +28,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>

--- a/public/education.html
+++ b/public/education.html
@@ -28,7 +28,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/experience.html
+++ b/public/experience.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/experience.html
+++ b/public/experience.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/experience.html
+++ b/public/experience.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body>
@@ -42,6 +42,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/index-old.html
+++ b/public/index-old.html
@@ -10,6 +10,8 @@
     <title>Portfolio - Mukharbek Organokov</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="stylesheet" href="/src/css/style.css">
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="utf-8" />
@@ -21,7 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="apple-touch-icon" href="/assets/favicon.svg" />
     <meta name="author" content="Mukharbek Organokov">
-    <meta name="theme-color" content="#6366f1" />
+    <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
     <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />
@@ -23,7 +23,7 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
 </head>
 
 <body class="smooth-scroll-page">
@@ -41,6 +41,7 @@
             </ul>
             <div class="nav-actions">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">🌙</button>
+                <button class="palette-toggle" id="paletteToggle" aria-label="Switch colour palette" title="Switch colour palette">🟣</button>
                 <button class="mobile-menu-toggle" id="mobileMenuToggle"
                         aria-label="Open navigation menu" aria-expanded="false" aria-controls="navLinks">☰</button>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,8 @@
     <meta name="author" content="Mukharbek Organokov">
     <meta name="theme-color" content="#0a5c36" />
     <link rel="stylesheet" href="/src/css/style.css" />
-    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark');if(localStorage.getItem('palette')!=='default')document.documentElement.setAttribute('data-palette','alt')}();</script>
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
 </head>
 
 <body class="smooth-scroll-page">

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -12,6 +12,8 @@
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
     <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
+    <script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+    <script src="/src/js/theme-config.js"></script>
     <style>
         .policy-section {
             padding: 6rem 0 4rem;

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-palette="alt">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="alt">
 
 <head>
     <meta charset="UTF-8">
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://www.organokov.com/privacy">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="apple-touch-icon" href="/assets/favicon.svg">
-    <meta name="theme-color" content="#667eea">
+    <meta name="theme-color" content="#0a5c36">
     <link rel="stylesheet" href="/src/css/style.css">
     <style>
         .policy-section {

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1,3 +1,6 @@
+/* Colour palettes (default + alternates) live in theme.css — imported first
+   so its custom properties are available to every rule below. */
+@import url('theme.css');
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
 
 * {
@@ -7,37 +10,8 @@
 }
 
 :root {
-    /* =============================================
-       PALETTE TOKENS
-       To add an alternate theme: override these in
-       [data-palette="alt"] on <html> (stub at end).
-       ============================================= */
-
-    /* Core brand colours */
-    --primary-color:   #6366f1;
-    --primary-dark:    #4f46e5;
-    --secondary-color: #8b5cf6;
-    --accent-color:    #f0abfc;
-
-    /* RGB channels — lets every rgba() tint track the active palette */
-    --primary-rgb:    99, 102, 241;
-    --secondary-rgb: 139,  92, 246;
-    --accent-rgb:    236,  72, 153;
-    --mid-rgb:       168,  85, 247;   /* purple mid-stop */
-    --edu-start-rgb:  59, 130, 246;   /* blue used in education section */
-
-    /* Named gradients — derived from palette tokens */
-    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
-    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
-    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
-    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
-    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
-
-    /* ── Not palette-specific ── */
+    /* Non-colour design tokens.
+       Brand colours and gradients are defined in theme.css. */
     --text-primary: #0f172a;
     --text-secondary: #475569;
     --text-light: #94a3b8;
@@ -1592,38 +1566,3 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
 [data-theme="dark"] .smooth-scroll-page section#experience { background: var(--bg-primary)   !important; }
 [data-theme="dark"] .smooth-scroll-page section#education  { background: var(--bg-secondary) !important; }
 [data-theme="dark"] .smooth-scroll-page section#blog       { background: var(--bg-secondary) !important; }
-
-/* =============================================
-   ALTERNATE PALETTE
-   Add  data-palette="alt"  to <html> to activate.
-   Replace the indigo values below with your colours.
-   All gradients auto-derive from the tokens above them.
-   ============================================= */
-/* GREEN PALETTE — Castleton / British Racing / Gunmetal
-   Colours from: #0A5C36 #0F5132 #14452F #18392B #1D2E28
-   ============================================= */
-[data-palette="alt"] {
-    /* Core brand colours */
-    --primary-color:   #0a5c36;   /* Castleton green */
-    --primary-dark:    #0f5132;   /* Castleton green (dark) */
-    --secondary-color: #14452f;   /* British racing green */
-    --accent-color:    #86efac;   /* Light mint — bright highlights */
-
-    /* RGB channels — must match the hex values above (R, G, B) */
-    --primary-rgb:    10,  92,  54;   /* #0a5c36 */
-    --secondary-rgb:  20,  69,  47;   /* #14452f */
-    --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
-    --mid-rgb:        15,  81,  50;   /* #0f5132 */
-    --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
-
-    /* Gradients auto-derive from the tokens above */
-    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
-    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
-    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
-    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
-    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
-    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
-}

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -448,7 +448,7 @@ section {
 
 .timeline-company {
     font-size: 1rem;
-    color: var(--secondary-color);
+    color: var(--accent-text);
     margin-bottom: 1rem;
     font-style: normal;
     font-weight: 600;
@@ -1050,7 +1050,7 @@ section {
 .institution {
     font-size: 1.1rem;
     font-weight: 600;
-    color: var(--secondary-color);
+    color: var(--accent-text);
     margin: 0;
 }
 
@@ -1556,7 +1556,7 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
 [data-theme="dark"] .education-section { background: var(--bg-secondary); }
 [data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .education-info h3 { color: var(--text-primary); }
-[data-theme="dark"] .institution { color: var(--secondary-color); }
+[data-theme="dark"] .institution { color: var(--accent-text); }
 [data-theme="dark"] .highlight-item { background: rgba(var(--primary-rgb),0.1); color: var(--text-secondary); }
 [data-theme="dark"] .detail-item { color: var(--text-secondary); }
 [data-theme="dark"] .section-title { color: var(--text-primary); }

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1359,20 +1359,20 @@ a.logo { text-decoration: none; }
 }
 
 .palette-toggle {
-    background: none;
-    border: 1px solid rgba(var(--primary-rgb), 0.2);
-    border-radius: var(--radius-sm);
+    background: var(--primary-color);
+    border: 2px solid rgba(255, 255, 255, 0.75);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
+    border-radius: 50%;
     width: 34px; height: 34px;
-    display: flex; align-items: center; justify-content: center;
+    padding: 0;
     cursor: pointer;
-    font-size: 0.85rem;
-    transition: background var(--transition), border-color var(--transition), transform var(--transition);
+    font-size: 0;            /* hide any text node — the colour is the indicator */
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
     line-height: 1; flex-shrink: 0;
 }
 .palette-toggle:hover {
-    background: rgba(var(--primary-rgb), 0.08);
-    border-color: rgba(var(--primary-rgb), 0.4);
-    transform: scale(1.1);
+    transform: scale(1.12);
+    box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.35);
 }
 
 /* =============================================
@@ -1527,6 +1527,8 @@ a.logo { text-decoration: none; }
     --bg-primary: #0f172a;
     --bg-secondary: #1e293b;
     --bg-dark: #020617;
+    --surface: #1e293b;        /* card surface — overridden per palette */
+    --nav-bg: 15, 23, 42;      /* navbar bg channels — overridden per palette */
     --shadow-card: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 1px rgba(var(--primary-rgb),0.15);
     --shadow: 0 4px 16px rgba(0,0,0,0.4);
     --shadow-hover: 0 12px 36px rgba(var(--primary-rgb),0.35), 0 4px 12px rgba(0,0,0,0.4);
@@ -1537,24 +1539,24 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
                 border-color 0.3s ease, box-shadow 0.3s ease;
 }
 [data-theme="dark"] body { background: var(--bg-primary); color: var(--text-primary); }
-[data-theme="dark"] .navbar { background: rgba(15,23,42,0.88) !important; border-bottom-color: rgba(var(--primary-rgb),0.15); }
-[data-theme="dark"] .navbar.scrolled { background: rgba(15,23,42,0.98) !important; box-shadow: 0 2px 20px rgba(0,0,0,0.3) !important; }
+[data-theme="dark"] .navbar { background: rgba(var(--nav-bg),0.88) !important; border-bottom-color: rgba(var(--primary-rgb),0.15); }
+[data-theme="dark"] .navbar.scrolled { background: rgba(var(--nav-bg),0.98) !important; box-shadow: 0 2px 20px rgba(0,0,0,0.3) !important; }
 [data-theme="dark"] .nav-links a { color: var(--text-secondary); }
 [data-theme="dark"] .nav-links a:hover,
 [data-theme="dark"] .nav-links a.active { color: var(--primary-color); background: rgba(var(--primary-rgb),0.12); }
 [data-theme="dark"] .theme-toggle { border-color: rgba(var(--primary-rgb),0.25); color: var(--text-secondary); }
 [data-theme="dark"] .about { background: var(--bg-secondary); }
-[data-theme="dark"] .skill-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
+[data-theme="dark"] .skill-card { background: var(--surface); border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .skill-card p { color: var(--text-secondary); }
 [data-theme="dark"] .about-text { color: var(--text-secondary); }
-[data-theme="dark"] .timeline-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
+[data-theme="dark"] .timeline-content { background: var(--surface); border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .timeline-title { color: var(--text-primary); }
-[data-theme="dark"] .blog-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
+[data-theme="dark"] .blog-card { background: var(--surface); border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .blog-title { color: var(--text-primary); }
 [data-theme="dark"] .blog-excerpt { color: var(--text-secondary); }
 [data-theme="dark"] .blog-meta { border-top-color: rgba(255,255,255,0.07); color: var(--text-light); }
 [data-theme="dark"] .education-section { background: var(--bg-secondary); }
-[data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
+[data-theme="dark"] .education-content { background: var(--surface); border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .education-info h3 { color: var(--text-primary); }
 [data-theme="dark"] .institution { color: var(--accent-text); }
 [data-theme="dark"] .highlight-item { background: rgba(var(--primary-rgb),0.1); color: var(--text-secondary); }

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1384,6 +1384,23 @@ a.logo { text-decoration: none; }
     transform: rotate(15deg);
 }
 
+.palette-toggle {
+    background: none;
+    border: 1px solid rgba(var(--primary-rgb), 0.2);
+    border-radius: var(--radius-sm);
+    width: 34px; height: 34px;
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: background var(--transition), border-color var(--transition), transform var(--transition);
+    line-height: 1; flex-shrink: 0;
+}
+.palette-toggle:hover {
+    background: rgba(var(--primary-rgb), 0.08);
+    border-color: rgba(var(--primary-rgb), 0.4);
+    transform: scale(1.1);
+}
+
 /* =============================================
    NAVBAR SCROLLED STATE
    ============================================= */

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1582,21 +1582,24 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
    Replace the indigo values below with your colours.
    All gradients auto-derive from the tokens above them.
    ============================================= */
+/* GREEN PALETTE — Castleton / British Racing / Gunmetal
+   Colours from: #0A5C36 #0F5132 #14452F #18392B #1D2E28
+   ============================================= */
 [data-palette="alt"] {
     /* Core brand colours */
-    --primary-color:   #6366f1;   /* ← your primary hex */
-    --primary-dark:    #4f46e5;
-    --secondary-color: #8b5cf6;
-    --accent-color:    #f0abfc;
+    --primary-color:   #0a5c36;   /* Castleton green */
+    --primary-dark:    #0f5132;   /* Castleton green (dark) */
+    --secondary-color: #14452f;   /* British racing green */
+    --accent-color:    #86efac;   /* Light mint — bright highlights */
 
     /* RGB channels — must match the hex values above (R, G, B) */
-    --primary-rgb:    99, 102, 241;
-    --secondary-rgb: 139,  92, 246;
-    --accent-rgb:    236,  72, 153;
-    --mid-rgb:       168,  85, 247;
-    --edu-start-rgb:  59, 130, 246;
+    --primary-rgb:    10,  92,  54;   /* #0a5c36 */
+    --secondary-rgb:  20,  69,  47;   /* #14452f */
+    --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
+    --mid-rgb:        15,  81,  50;   /* #0f5132 */
+    --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
 
-    /* Gradients auto-derive — only override if you want a custom direction/stops */
+    /* Gradients auto-derive from the tokens above */
     --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
     --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
     --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -7,22 +7,47 @@
 }
 
 :root {
-    --primary-color: #6366f1;
-    --primary-dark: #4f46e5;
+    /* =============================================
+       PALETTE TOKENS
+       To add an alternate theme: override these in
+       [data-palette="alt"] on <html> (stub at end).
+       ============================================= */
+
+    /* Core brand colours */
+    --primary-color:   #6366f1;
+    --primary-dark:    #4f46e5;
     --secondary-color: #8b5cf6;
-    --accent-color: #f0abfc;
+    --accent-color:    #f0abfc;
+
+    /* RGB channels — lets every rgba() tint track the active palette */
+    --primary-rgb:    99, 102, 241;
+    --secondary-rgb: 139,  92, 246;
+    --accent-rgb:    236,  72, 153;
+    --mid-rgb:       168,  85, 247;   /* purple mid-stop */
+    --edu-start-rgb:  59, 130, 246;   /* blue used in education section */
+
+    /* Named gradients — derived from palette tokens */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+
+    /* ── Not palette-specific ── */
     --text-primary: #0f172a;
     --text-secondary: #475569;
     --text-light: #94a3b8;
     --bg-primary: #ffffff;
     --bg-secondary: #f8fafc;
     --bg-dark: #0f172a;
-    --gradient: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-    --gradient-warm: linear-gradient(135deg, #6366f1 0%, #a855f7 50%, #ec4899 100%);
     --shadow-sm: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
-    --shadow: 0 4px 16px rgba(99, 102, 241, 0.10), 0 1px 4px rgba(0,0,0,0.06);
-    --shadow-hover: 0 12px 36px rgba(99, 102, 241, 0.22), 0 4px 12px rgba(0,0,0,0.08);
-    --shadow-card: 0 2px 8px rgba(0,0,0,0.06), 0 0 0 1px rgba(99,102,241,0.06);
+    --shadow: 0 4px 16px rgba(var(--primary-rgb), 0.10), 0 1px 4px rgba(0,0,0,0.06);
+    --shadow-hover: 0 12px 36px rgba(var(--primary-rgb), 0.22), 0 4px 12px rgba(0,0,0,0.08);
+    --shadow-card: 0 2px 8px rgba(0,0,0,0.06), 0 0 0 1px rgba(var(--primary-rgb), 0.06);
     --radius-sm: 8px;
     --radius: 14px;
     --radius-lg: 20px;
@@ -52,7 +77,7 @@ html {
     background: rgba(255, 255, 255, 0.85);
     backdrop-filter: blur(20px) saturate(180%);
     -webkit-backdrop-filter: blur(20px) saturate(180%);
-    border-bottom: 1px solid rgba(99, 102, 241, 0.08);
+    border-bottom: 1px solid rgba(var(--primary-rgb), 0.08);
     z-index: 1000;
     padding: 1rem 0;
     transition: background var(--transition), box-shadow var(--transition);
@@ -97,7 +122,7 @@ html {
 .nav-links a:hover,
 .nav-links a.active {
     color: var(--primary-color);
-    background: rgba(99, 102, 241, 0.07);
+    background: rgba(var(--primary-rgb), 0.07);
 }
 
 .nav-links a::after {
@@ -144,7 +169,7 @@ html {
     inset: 0;
     background:
         radial-gradient(ellipse 80% 50% at 50% -20%, rgba(255,255,255,0.18) 0%, transparent 60%),
-        radial-gradient(ellipse 40% 40% at 80% 80%, rgba(236,72,153,0.25) 0%, transparent 60%),
+        radial-gradient(ellipse 40% 40% at 80% 80%, rgba(var(--accent-rgb),0.25) 0%, transparent 60%),
         repeating-linear-gradient(45deg,
             rgba(255,255,255,0.04) 0px,
             rgba(255,255,255,0.04) 1px,
@@ -309,7 +334,7 @@ section {
     box-shadow: var(--shadow-card);
     transition: transform var(--transition), box-shadow var(--transition);
     text-align: center;
-    border: 1px solid rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(var(--primary-rgb), 0.08);
     position: relative;
     overflow: hidden;
     aspect-ratio: 1 / 1;
@@ -378,7 +403,7 @@ section {
     top: 0;
     bottom: 0;
     width: 2px;
-    background: linear-gradient(180deg, #6366f1 0%, #a855f7 50%, #ec4899 100%);
+    background: var(--gradient-timeline);
     transform: translateX(-50%);
     border-radius: 2px;
 }
@@ -393,7 +418,7 @@ section {
     padding: 2rem;
     border-radius: var(--radius);
     box-shadow: var(--shadow-card);
-    border: 1px solid rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(var(--primary-rgb), 0.08);
     width: calc(50% - 20px);
     position: relative;
     transition: transform var(--transition), box-shadow var(--transition);
@@ -418,17 +443,17 @@ section {
     top: 2rem;
     width: 18px;
     height: 18px;
-    background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+    background: var(--gradient-dot);
     border-radius: 50%;
     transform: translateX(-50%);
     z-index: 1;
     border: 3px solid white;
-    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18);
+    box-shadow: 0 0 0 4px rgba(var(--primary-rgb), 0.18);
 }
 
 .timeline-date {
     padding: 0.4rem 1rem;
-    background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+    background: var(--gradient-dot);
     color: white;
     border-radius: var(--radius-full);
     font-size: 0.8rem;
@@ -469,7 +494,7 @@ section {
     border-radius: var(--radius-lg);
     overflow: hidden;
     box-shadow: var(--shadow-card);
-    border: 1px solid rgba(99, 102, 241, 0.07);
+    border: 1px solid rgba(var(--primary-rgb), 0.07);
     transition: transform var(--transition), box-shadow var(--transition);
     display: flex;
     flex-direction: column;
@@ -707,7 +732,7 @@ section {
 
 .submit-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(99, 102, 241, 0.4);
+    box-shadow: 0 8px 20px rgba(var(--primary-rgb), 0.4);
 }
 
 .submit-btn:active {
@@ -790,7 +815,7 @@ section {
     opacity: 0;
     visibility: hidden;
     z-index: 999;
-    box-shadow: 0 4px 14px rgba(99, 102, 241, 0.35);
+    box-shadow: 0 4px 14px rgba(var(--primary-rgb), 0.35);
 }
 
 .back-to-top.visible {
@@ -800,7 +825,7 @@ section {
 
 .back-to-top:hover {
     transform: translateY(-3px);
-    box-shadow: 0 8px 20px rgba(99, 102, 241, 0.5);
+    box-shadow: 0 8px 20px rgba(var(--primary-rgb), 0.5);
 }
 
 /* Loading indicator */
@@ -993,7 +1018,7 @@ section {
     top: 0;
     bottom: 0;
     width: 3px;
-    background: linear-gradient(180deg, #3b82f6 0%, #8b5cf6 50%, #ec4899 100%);
+    background: var(--gradient-edu-line);
     border-radius: 2px;
 }
 
@@ -1010,10 +1035,10 @@ section {
     top: 30px;
     width: 20px;
     height: 20px;
-    background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+    background: var(--gradient-edu-dot);
     border-radius: 50%;
     border: 4px solid #f8fafc;
-    box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.2);
+    box-shadow: 0 0 0 3px rgba(var(--secondary-rgb), 0.2);
     z-index: 2;
 }
 
@@ -1022,7 +1047,7 @@ section {
     border-radius: 16px;
     padding: 2rem;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border-left: 4px solid #8b5cf6;
+    border-left: 4px solid var(--secondary-color);
     transition: all 0.3s ease;
     position: relative;
 }
@@ -1051,13 +1076,13 @@ section {
 .institution {
     font-size: 1.1rem;
     font-weight: 600;
-    color: #8b5cf6;
+    color: var(--secondary-color);
     margin: 0;
 }
 
 .education-period {
     padding: 0.5rem 1.25rem;
-    background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+    background: var(--gradient-edu-dot);
     color: white;
     border-radius: 50px;
     font-size: 0.875rem;
@@ -1344,7 +1369,7 @@ a.logo { text-decoration: none; }
    ============================================= */
 .theme-toggle {
     background: none;
-    border: 1px solid rgba(99, 102, 241, 0.2);
+    border: 1px solid rgba(var(--primary-rgb), 0.2);
     border-radius: var(--radius-sm);
     width: 34px; height: 34px;
     display: flex; align-items: center; justify-content: center;
@@ -1354,8 +1379,8 @@ a.logo { text-decoration: none; }
     line-height: 1; flex-shrink: 0;
 }
 .theme-toggle:hover {
-    background: rgba(99, 102, 241, 0.08);
-    border-color: rgba(99, 102, 241, 0.4);
+    background: rgba(var(--primary-rgb), 0.08);
+    border-color: rgba(var(--primary-rgb), 0.4);
     transform: rotate(15deg);
 }
 
@@ -1374,7 +1399,7 @@ a.logo { text-decoration: none; }
     content: '';
     display: block;
     width: 32px; height: 32px;
-    border: 3px solid rgba(99, 102, 241, 0.12);
+    border: 3px solid rgba(var(--primary-rgb), 0.12);
     border-top-color: var(--primary-color);
     border-radius: 50%;
     animation: spin 0.7s linear infinite;
@@ -1454,7 +1479,7 @@ a.logo { text-decoration: none; }
     transition: background var(--transition), color var(--transition), transform var(--transition);
     border: 1px solid rgba(255,255,255,0.08);
 }
-.footer-social-link:hover { background: rgba(99,102,241,0.28); color: white; transform: translateY(-2px); }
+.footer-social-link:hover { background: rgba(var(--primary-rgb),0.28); color: white; transform: translateY(-2px); }
 .footer-social-link svg { flex-shrink: 0; }
 
 /* =============================================
@@ -1494,11 +1519,11 @@ a.logo { text-decoration: none; }
         transparent 1px, transparent 20px);
     pointer-events: none; z-index: 0;
 }
-.blog-image--1 { background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%); }
-.blog-image--2 { background: linear-gradient(135deg, #0ea5e9 0%, #6366f1 100%); }
+.blog-image--1 { background: var(--gradient-blog-1); }
+.blog-image--2 { background: var(--gradient-blog-2); }
 .blog-image--3 { background: linear-gradient(135deg, #10b981 0%, #059669 100%); }
 .blog-image--4 { background: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%); }
-.blog-image--5 { background: linear-gradient(135deg, #ec4899 0%, #8b5cf6 100%); }
+.blog-image--5 { background: var(--gradient-blog-5); }
 .blog-image--6 { background: linear-gradient(135deg, #06b6d4 0%, #0284c7 100%); }
 
 /* =============================================
@@ -1511,9 +1536,9 @@ a.logo { text-decoration: none; }
     --bg-primary: #0f172a;
     --bg-secondary: #1e293b;
     --bg-dark: #020617;
-    --shadow-card: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 1px rgba(99,102,241,0.15);
+    --shadow-card: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 1px rgba(var(--primary-rgb),0.15);
     --shadow: 0 4px 16px rgba(0,0,0,0.4);
-    --shadow-hover: 0 12px 36px rgba(99,102,241,0.35), 0 4px 12px rgba(0,0,0,0.4);
+    --shadow-hover: 0 12px 36px rgba(var(--primary-rgb),0.35), 0 4px 12px rgba(0,0,0,0.4);
 }
 body, .navbar, .skill-card, .timeline-content, .blog-card,
 .education-content, .loading, .footer {
@@ -1521,27 +1546,27 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
                 border-color 0.3s ease, box-shadow 0.3s ease;
 }
 [data-theme="dark"] body { background: var(--bg-primary); color: var(--text-primary); }
-[data-theme="dark"] .navbar { background: rgba(15,23,42,0.88) !important; border-bottom-color: rgba(99,102,241,0.15); }
+[data-theme="dark"] .navbar { background: rgba(15,23,42,0.88) !important; border-bottom-color: rgba(var(--primary-rgb),0.15); }
 [data-theme="dark"] .navbar.scrolled { background: rgba(15,23,42,0.98) !important; box-shadow: 0 2px 20px rgba(0,0,0,0.3) !important; }
 [data-theme="dark"] .nav-links a { color: var(--text-secondary); }
 [data-theme="dark"] .nav-links a:hover,
-[data-theme="dark"] .nav-links a.active { color: var(--primary-color); background: rgba(99,102,241,0.12); }
-[data-theme="dark"] .theme-toggle { border-color: rgba(99,102,241,0.25); color: var(--text-secondary); }
+[data-theme="dark"] .nav-links a.active { color: var(--primary-color); background: rgba(var(--primary-rgb),0.12); }
+[data-theme="dark"] .theme-toggle { border-color: rgba(var(--primary-rgb),0.25); color: var(--text-secondary); }
 [data-theme="dark"] .about { background: var(--bg-secondary); }
-[data-theme="dark"] .skill-card { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .skill-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .skill-card p { color: var(--text-secondary); }
 [data-theme="dark"] .about-text { color: var(--text-secondary); }
-[data-theme="dark"] .timeline-content { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .timeline-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .timeline-title { color: var(--text-primary); }
-[data-theme="dark"] .blog-card { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .blog-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .blog-title { color: var(--text-primary); }
 [data-theme="dark"] .blog-excerpt { color: var(--text-secondary); }
 [data-theme="dark"] .blog-meta { border-top-color: rgba(255,255,255,0.07); color: var(--text-light); }
 [data-theme="dark"] .education-section { background: var(--bg-secondary); }
-[data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(99,102,241,0.14); }
+[data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .education-info h3 { color: var(--text-primary); }
 [data-theme="dark"] .institution { color: var(--secondary-color); }
-[data-theme="dark"] .highlight-item { background: rgba(99,102,241,0.1); color: var(--text-secondary); }
+[data-theme="dark"] .highlight-item { background: rgba(var(--primary-rgb),0.1); color: var(--text-secondary); }
 [data-theme="dark"] .detail-item { color: var(--text-secondary); }
 [data-theme="dark"] .section-title { color: var(--text-primary); }
 [data-theme="dark"] .loading { background: var(--bg-primary); }
@@ -1550,3 +1575,35 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
 [data-theme="dark"] .smooth-scroll-page section#experience { background: var(--bg-primary)   !important; }
 [data-theme="dark"] .smooth-scroll-page section#education  { background: var(--bg-secondary) !important; }
 [data-theme="dark"] .smooth-scroll-page section#blog       { background: var(--bg-secondary) !important; }
+
+/* =============================================
+   ALTERNATE PALETTE
+   Add  data-palette="alt"  to <html> to activate.
+   Replace the indigo values below with your colours.
+   All gradients auto-derive from the tokens above them.
+   ============================================= */
+[data-palette="alt"] {
+    /* Core brand colours */
+    --primary-color:   #6366f1;   /* ← your primary hex */
+    --primary-dark:    #4f46e5;
+    --secondary-color: #8b5cf6;
+    --accent-color:    #f0abfc;
+
+    /* RGB channels — must match the hex values above (R, G, B) */
+    --primary-rgb:    99, 102, 241;
+    --secondary-rgb: 139,  92, 246;
+    --accent-rgb:    236,  72, 153;
+    --mid-rgb:       168,  85, 247;
+    --edu-start-rgb:  59, 130, 246;
+
+    /* Gradients auto-derive — only override if you want a custom direction/stops */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+}

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -183,7 +183,7 @@ html {
 }
 
 .hero p {
-    font-size: clamp(1.1rem, 2vw, 1.35rem);
+    font-size: clamp(1.35rem, 2.6vw, 1.7rem);
     margin-bottom: 2.5rem;
     opacity: 0.88;
     font-weight: 400;

--- a/public/src/css/theme.css
+++ b/public/src/css/theme.css
@@ -81,3 +81,133 @@
     --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
     --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
 }
+
+/* Castleton green — matching deep-green dark-mode backgrounds */
+[data-theme="dark"][data-palette="alt"] {
+    --bg-primary:   #0a1f15;
+    --bg-secondary: #102a1c;
+    --bg-dark:      #051009;
+    --surface:      #14301f;
+    --nav-bg:       10, 31, 21;
+    --accent-text:  #4ade80;   /* brighter label green for dark bg */
+}
+
+/* =====================================================================
+   EXPERIMENTAL EXTRA PALETTES  (selectable via the navbar swatch)
+   ---------------------------------------------------------------------
+   Each block only overrides the ~10 colour tokens — every gradient,
+   shadow and tint AUTO-DERIVES from them (the gradient definitions in
+   :root resolve var() lazily against the active palette).
+   Each green palette has a paired dark-mode block giving it matching
+   deep-green backgrounds instead of the default slate.
+   ===================================================================== */
+
+/* 1 — Deep Forest Metallic (moss green + metallic-gold education accent) */
+[data-palette="forest"] {
+    --primary-color:   #2e5d4f;   /* sea moss */
+    --primary-dark:    #1f4034;
+    --secondary-color: #16352d;   /* deep pine */
+    --accent-color:    #7fb295;   /* sage highlight */
+    --accent-text:     #2e6b50;   /* label green on white (~5:1) */
+    --primary-rgb:     46,  93,  79;
+    --secondary-rgb:   22,  53,  45;
+    --accent-rgb:     127, 178, 149;   /* sage */
+    --mid-rgb:         53, 112,  86;   /* readable mid for badges */
+    --edu-start-rgb:  197, 165, 114;   /* metallic gold */
+}
+[data-theme="dark"][data-palette="forest"] {
+    --bg-primary:   #0b1f1a;
+    --bg-secondary: #13312b;
+    --bg-dark:      #060f0c;
+    --surface:      #16352d;
+    --nav-bg:       11, 31, 26;
+    --accent-text:  #9ccbae;
+}
+
+/* 2 — Emerald Noir (sleek SaaS emerald + mint glow) */
+[data-palette="emerald"] {
+    --primary-color:   #1b6b52;   /* emerald */
+    --primary-dark:    #124a39;
+    --secondary-color: #0f2a22;
+    --accent-color:    #3ddc97;   /* mint shine */
+    --accent-text:     #047857;
+    --primary-rgb:     27, 107,  82;
+    --secondary-rgb:   15,  42,  34;
+    --accent-rgb:      61, 220, 151;   /* mint */
+    --mid-rgb:         24, 120,  90;
+    --edu-start-rgb:   13, 148, 136;   /* teal */
+}
+[data-theme="dark"][data-palette="emerald"] {
+    --bg-primary:   #08120f;
+    --bg-secondary: #0f2a22;
+    --bg-dark:      #050b09;
+    --surface:      #123026;
+    --nav-bg:       8, 18, 15;
+    --accent-text:  #3ddc97;
+}
+
+/* 3 — Dark Sea Patina (oxidised sea-green, editorial) */
+[data-palette="patina"] {
+    --primary-color:   #2f6f65;   /* sea green */
+    --primary-dark:    #1f4d46;
+    --secondary-color: #14302e;
+    --accent-color:    #6fb3a8;   /* patina mist */
+    --accent-text:     #2a665d;
+    --primary-rgb:     47, 111, 101;
+    --secondary-rgb:   20,  48,  46;
+    --accent-rgb:     111, 179, 168;   /* patina mist */
+    --mid-rgb:         45, 117, 105;
+    --edu-start-rgb:   47, 143, 127;
+}
+[data-theme="dark"][data-palette="patina"] {
+    --bg-primary:   #0a1818;
+    --bg-secondary: #14302e;
+    --bg-dark:      #050d0d;
+    --surface:      #173432;
+    --nav-bg:       10, 24, 24;
+    --accent-text:  #6fb3a8;
+}
+
+/* 4 — Hunter Chrome (deep hunter green + chrome muted) */
+[data-palette="hunter"] {
+    --primary-color:   #2a4a33;   /* hunter green */
+    --primary-dark:    #1c3324;
+    --secondary-color: #1a2a1f;
+    --accent-color:    #8fa68e;   /* chrome muted */
+    --accent-text:     #44734f;
+    --primary-rgb:     42,  74,  51;
+    --secondary-rgb:   26,  42,  31;
+    --accent-rgb:     143, 166, 142;   /* chrome */
+    --mid-rgb:         58,  90,  68;
+    --edu-start-rgb:  105, 130, 105;
+}
+[data-theme="dark"][data-palette="hunter"] {
+    --bg-primary:   #0d1410;
+    --bg-secondary: #1a2a1f;
+    --bg-dark:      #070b08;
+    --surface:      #1d2e22;
+    --nav-bg:       13, 20, 16;
+    --accent-text:  #b6c7b0;
+}
+
+/* 5 — Jade Obsidian (jewel jade + warm-brass education accent) */
+[data-palette="jade"] {
+    --primary-color:   #1f5f4a;   /* jade */
+    --primary-dark:    #154235;
+    --secondary-color: #102a22;
+    --accent-color:    #46c2a0;   /* bright jade */
+    --accent-text:     #15795a;
+    --primary-rgb:     31,  95,  74;
+    --secondary-rgb:   16,  42,  34;
+    --accent-rgb:      70, 194, 160;   /* bright jade */
+    --mid-rgb:         31, 115,  89;
+    --edu-start-rgb:  168, 137, 107;   /* warm brass */
+}
+[data-theme="dark"][data-palette="jade"] {
+    --bg-primary:   #06100d;
+    --bg-secondary: #102a22;
+    --bg-dark:      #040a08;
+    --surface:      #133026;
+    --nav-bg:       6, 16, 13;
+    --accent-text:  #46c2a0;
+}

--- a/public/src/css/theme.css
+++ b/public/src/css/theme.css
@@ -68,7 +68,7 @@
     --secondary-rgb:  20,  69,  47;   /* #14452f */
     --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
     --mid-rgb:        21, 128,  61;   /* #15803d — lightened so date badges read brighter */
-    --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
+    --edu-start-rgb:  21, 128,  61;   /* #15803d — matches --accent-text so institution name & badge share the same green */
 
     /* Gradients auto-derive from the tokens above */
     --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);

--- a/public/src/css/theme.css
+++ b/public/src/css/theme.css
@@ -30,6 +30,7 @@
     --primary-dark:    #4f46e5;
     --secondary-color: #8b5cf6;
     --accent-color:    #f0abfc;
+    --accent-text:     var(--secondary-color);   /* dates / company / institution labels */
 
     /* RGB channels — lets every rgba() tint track the active palette */
     --primary-rgb:    99, 102, 241;
@@ -60,12 +61,13 @@
     --primary-dark:    #0f5132;   /* Castleton green (dark) */
     --secondary-color: #14452f;   /* British racing green */
     --accent-color:    #86efac;   /* Light mint — bright highlights */
+    --accent-text:     #15803d;   /* lighter green for dates / company / institution labels */
 
     /* RGB channels — must match the hex values above (R, G, B) */
     --primary-rgb:    10,  92,  54;   /* #0a5c36 */
     --secondary-rgb:  20,  69,  47;   /* #14452f */
     --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
-    --mid-rgb:        15,  81,  50;   /* #0f5132 */
+    --mid-rgb:        21, 128,  61;   /* #15803d — lightened so date badges read brighter */
     --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
 
     /* Gradients auto-derive from the tokens above */

--- a/public/src/css/theme.css
+++ b/public/src/css/theme.css
@@ -1,0 +1,81 @@
+/* =====================================================================
+   THEME — COLOUR PALETTES
+   ---------------------------------------------------------------------
+   This is the single place to edit colours or add new palettes.
+   It is pulled into style.css via:   @import url('theme.css');
+
+   • :root                 → the DEFAULT palette (indigo / violet)
+   • [data-palette="alt"]  → the ALTERNATE palette (Castleton green)
+
+   Which one is shown is decided by  src/js/theme-config.js
+   (and the in-page palette toggle button). To add a third palette,
+   copy the [data-palette="alt"] block, rename it e.g.
+   [data-palette="ocean"], change the values, then reference "ocean"
+   from theme-config.js.
+
+   HOW THE TOKENS WORK
+   • --primary-color / --secondary-color / --accent-color  → hex values
+   • --*-rgb            → the SAME colours as "R, G, B" channels so that
+                          translucent tints can be written as
+                          rgba(var(--primary-rgb), 0.1)
+   • --gradient-*       → ready-made gradients derived from the tokens
+   ===================================================================== */
+
+/* ---------------------------------------------------------------------
+   DEFAULT PALETTE — Indigo / Violet
+   --------------------------------------------------------------------- */
+:root {
+    /* Core brand colours */
+    --primary-color:   #6366f1;
+    --primary-dark:    #4f46e5;
+    --secondary-color: #8b5cf6;
+    --accent-color:    #f0abfc;
+
+    /* RGB channels — lets every rgba() tint track the active palette */
+    --primary-rgb:    99, 102, 241;
+    --secondary-rgb: 139,  92, 246;
+    --accent-rgb:    236,  72, 153;
+    --mid-rgb:       168,  85, 247;   /* purple mid-stop */
+    --edu-start-rgb:  59, 130, 246;   /* blue used in education section */
+
+    /* Named gradients — derived from palette tokens */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+}
+
+/* ---------------------------------------------------------------------
+   ALTERNATE PALETTE — Castleton / British Racing Green
+   Source swatch: #0A5C36 #0F5132 #14452F #18392B #1D2E28
+   --------------------------------------------------------------------- */
+[data-palette="alt"] {
+    /* Core brand colours */
+    --primary-color:   #0a5c36;   /* Castleton green */
+    --primary-dark:    #0f5132;   /* Castleton green (dark) */
+    --secondary-color: #14452f;   /* British racing green */
+    --accent-color:    #86efac;   /* Light mint — bright highlights */
+
+    /* RGB channels — must match the hex values above (R, G, B) */
+    --primary-rgb:    10,  92,  54;   /* #0a5c36 */
+    --secondary-rgb:  20,  69,  47;   /* #14452f */
+    --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
+    --mid-rgb:        15,  81,  50;   /* #0f5132 */
+    --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
+
+    /* Gradients auto-derive from the tokens above */
+    --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+    --gradient-warm:     linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-timeline: linear-gradient(180deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-dot:      linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-edu-line: linear-gradient(180deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 50%, rgb(var(--accent-rgb)) 100%);
+    --gradient-edu-dot:  linear-gradient(135deg, rgb(var(--edu-start-rgb)) 0%, var(--secondary-color) 100%);
+    --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
+    --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
+    --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+}

--- a/public/src/js/aggregate.js
+++ b/public/src/js/aggregate.js
@@ -345,7 +345,7 @@ function setupPaletteToggle() {
         return;
     }
     const setIcon = (isGreen) => {
-        btn.textContent = isGreen ? '🟣' : '🌿';
+        btn.textContent = isGreen ? '🟣' : '🟢';
         btn.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
     };
     setIcon(document.documentElement.hasAttribute('data-palette'));

--- a/public/src/js/aggregate.js
+++ b/public/src/js/aggregate.js
@@ -344,14 +344,15 @@ function setupPaletteToggle() {
         btn.style.display = 'none';
         return;
     }
-    const setIcon = (isGreen) => {
-        btn.textContent = isGreen ? '🟣' : '🟢';
-        btn.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+    const sync = () => {
+        btn.textContent = '';
+        const label = window.__paletteLabel ? window.__paletteLabel() : '';
+        btn.title = label ? `Theme: ${label} — click to change` : 'Change colour theme';
+        btn.setAttribute('aria-label', label ? `Colour theme: ${label}. Click to change.` : 'Change colour theme');
     };
-    setIcon(document.documentElement.hasAttribute('data-palette'));
+    sync();
     btn.addEventListener('click', () => {
-        const next = document.documentElement.hasAttribute('data-palette') ? 'indigo' : 'green';
-        window.__applyPalette(next);
-        setIcon(next === 'green');
+        if (window.__cyclePalette) window.__cyclePalette();
+        sync();
     });
 }

--- a/public/src/js/aggregate.js
+++ b/public/src/js/aggregate.js
@@ -328,7 +328,32 @@ async function init() {
 
 // Start when DOM is ready
 if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
+    document.addEventListener('DOMContentLoaded', () => {
+        init();
+        setupPaletteToggle();
+    });
 } else {
     init();
+    setupPaletteToggle();
+}
+
+function setupPaletteToggle() {
+    const btn = document.getElementById('paletteToggle');
+    if (!btn) return;
+    const setIcon = (isGreen) => {
+        btn.textContent = isGreen ? '🟣' : '🌿';
+        btn.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+    };
+    setIcon(document.documentElement.hasAttribute('data-palette'));
+    btn.addEventListener('click', () => {
+        const isGreen = document.documentElement.hasAttribute('data-palette');
+        if (isGreen) {
+            document.documentElement.removeAttribute('data-palette');
+            localStorage.setItem('palette', 'default');
+        } else {
+            document.documentElement.setAttribute('data-palette', 'alt');
+            localStorage.setItem('palette', 'alt');
+        }
+        setIcon(!isGreen);
+    });
 }

--- a/public/src/js/aggregate.js
+++ b/public/src/js/aggregate.js
@@ -340,20 +340,18 @@ if (document.readyState === 'loading') {
 function setupPaletteToggle() {
     const btn = document.getElementById('paletteToggle');
     if (!btn) return;
+    if (window.SITE_THEME && window.SITE_THEME.enablePaletteToggle === false) {
+        btn.style.display = 'none';
+        return;
+    }
     const setIcon = (isGreen) => {
         btn.textContent = isGreen ? '🟣' : '🌿';
         btn.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
     };
     setIcon(document.documentElement.hasAttribute('data-palette'));
     btn.addEventListener('click', () => {
-        const isGreen = document.documentElement.hasAttribute('data-palette');
-        if (isGreen) {
-            document.documentElement.removeAttribute('data-palette');
-            localStorage.setItem('palette', 'default');
-        } else {
-            document.documentElement.setAttribute('data-palette', 'alt');
-            localStorage.setItem('palette', 'alt');
-        }
-        setIcon(!isGreen);
+        const next = document.documentElement.hasAttribute('data-palette') ? 'indigo' : 'green';
+        window.__applyPalette(next);
+        setIcon(next === 'green');
     });
 }

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -146,21 +146,22 @@ themeToggle?.addEventListener('click', () => {
     setThemeIcon(next === 'dark');
 });
 
-// ── Palette toggle ──
+// ── Palette swatch (cycles through palettes) ──
 const paletteToggle = document.getElementById('paletteToggle');
 if (paletteToggle) {
     if (window.SITE_THEME && window.SITE_THEME.enablePaletteToggle === false) {
         paletteToggle.style.display = 'none';
     } else {
-        const setPaletteIcon = (isGreen) => {
-            paletteToggle.textContent = isGreen ? '🟣' : '🟢';
-            paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+        const syncPalette = () => {
+            paletteToggle.textContent = '';
+            const label = window.__paletteLabel ? window.__paletteLabel() : '';
+            paletteToggle.title = label ? `Theme: ${label} — click to change` : 'Change colour theme';
+            paletteToggle.setAttribute('aria-label', label ? `Colour theme: ${label}. Click to change.` : 'Change colour theme');
         };
-        setPaletteIcon(document.documentElement.hasAttribute('data-palette'));
+        syncPalette();
         paletteToggle.addEventListener('click', () => {
-            const next = document.documentElement.hasAttribute('data-palette') ? 'indigo' : 'green';
-            window.__applyPalette(next);
-            setPaletteIcon(next === 'green');
+            if (window.__cyclePalette) window.__cyclePalette();
+            syncPalette();
         });
     }
 }

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -148,23 +148,22 @@ themeToggle?.addEventListener('click', () => {
 
 // ── Palette toggle ──
 const paletteToggle = document.getElementById('paletteToggle');
-const setPaletteIcon = (isGreen) => {
-    if (!paletteToggle) return;
-    paletteToggle.textContent = isGreen ? '🟣' : '🌿';
-    paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
-};
-setPaletteIcon(document.documentElement.hasAttribute('data-palette'));
-paletteToggle?.addEventListener('click', () => {
-    const isGreen = document.documentElement.hasAttribute('data-palette');
-    if (isGreen) {
-        document.documentElement.removeAttribute('data-palette');
-        localStorage.setItem('palette', 'default');
+if (paletteToggle) {
+    if (window.SITE_THEME && window.SITE_THEME.enablePaletteToggle === false) {
+        paletteToggle.style.display = 'none';
     } else {
-        document.documentElement.setAttribute('data-palette', 'alt');
-        localStorage.setItem('palette', 'alt');
+        const setPaletteIcon = (isGreen) => {
+            paletteToggle.textContent = isGreen ? '🟣' : '🌿';
+            paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+        };
+        setPaletteIcon(document.documentElement.hasAttribute('data-palette'));
+        paletteToggle.addEventListener('click', () => {
+            const next = document.documentElement.hasAttribute('data-palette') ? 'indigo' : 'green';
+            window.__applyPalette(next);
+            setPaletteIcon(next === 'green');
+        });
     }
-    setPaletteIcon(!isGreen);
-});
+}
 
 // ── Scroll progress bar ──
 const scrollProgress = document.getElementById('scrollProgress');

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -153,7 +153,7 @@ if (paletteToggle) {
         paletteToggle.style.display = 'none';
     } else {
         const setPaletteIcon = (isGreen) => {
-            paletteToggle.textContent = isGreen ? '🟣' : '🌿';
+            paletteToggle.textContent = isGreen ? '🟣' : '🟢';
             paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
         };
         setPaletteIcon(document.documentElement.hasAttribute('data-palette'));

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -146,6 +146,26 @@ themeToggle?.addEventListener('click', () => {
     setThemeIcon(next === 'dark');
 });
 
+// ── Palette toggle ──
+const paletteToggle = document.getElementById('paletteToggle');
+const setPaletteIcon = (isGreen) => {
+    if (!paletteToggle) return;
+    paletteToggle.textContent = isGreen ? '🟣' : '🌿';
+    paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+};
+setPaletteIcon(document.documentElement.hasAttribute('data-palette'));
+paletteToggle?.addEventListener('click', () => {
+    const isGreen = document.documentElement.hasAttribute('data-palette');
+    if (isGreen) {
+        document.documentElement.removeAttribute('data-palette');
+        localStorage.setItem('palette', 'default');
+    } else {
+        document.documentElement.setAttribute('data-palette', 'alt');
+        localStorage.setItem('palette', 'alt');
+    }
+    setPaletteIcon(!isGreen);
+});
+
 // ── Scroll progress bar ──
 const scrollProgress = document.getElementById('scrollProgress');
 if (scrollProgress) {

--- a/public/src/js/theme-config.js
+++ b/public/src/js/theme-config.js
@@ -2,15 +2,28 @@
    THEME CONFIG  —  behaviour settings (edit the values in CONFIG below)
    ---------------------------------------------------------------------
    The actual COLOURS live in  src/css/theme.css.
-   This file decides WHICH palette is shown and whether visitors can
-   switch it. It is loaded in the <head> of every page so the choice is
-   applied before the first paint (no colour flash).
+   This file decides WHICH palettes exist, which one is the default, and
+   whether visitors can switch. Loaded in the <head> of every page so the
+   choice is applied before first paint (no colour flash).
    ===================================================================== */
 
 window.SITE_THEME = {
-    /* Palette shown to first-time visitors (before they pick one):
-         'green'  → Castleton green   (theme.css [data-palette="alt"])
-         'indigo' → original indigo   (theme.css :root)                  */
+    /* Palettes the navbar swatch cycles through, in order.
+         key   → identifier saved to localStorage
+         label → shown in the button tooltip
+         attr  → the data-palette attribute value
+                 (null  = the default :root palette, i.e. Indigo)        */
+    palettes: [
+        { key: 'green',   label: 'Castleton Green', attr: 'alt' },
+        { key: 'forest',  label: 'Deep Forest',     attr: 'forest' },
+        { key: 'emerald', label: 'Emerald Noir',    attr: 'emerald' },
+        { key: 'patina',  label: 'Sea Patina',      attr: 'patina' },
+        { key: 'hunter',  label: 'Hunter Green',    attr: 'hunter' },
+        { key: 'jade',    label: 'Jade Obsidian',   attr: 'jade' },
+        { key: 'indigo',  label: 'Indigo',          attr: null },
+    ],
+
+    /* Palette shown to first-time visitors (must be a key above).       */
     defaultPalette: 'green',
 
     /* Show the palette switch button in the navbar?  true | false       */
@@ -20,29 +33,54 @@ window.SITE_THEME = {
 /* ---------------------------------------------------------------------
    Internals — no need to edit below this line.
    Applies the resolved palette immediately (runs before <body> paints)
-   and exposes window.__applyPalette() for the navbar toggle button.
+   and exposes helpers used by the navbar swatch in main.js/aggregate.js.
    --------------------------------------------------------------------- */
 (function () {
-    var cfg = window.SITE_THEME || {};
+    var cfg  = window.SITE_THEME || {};
+    var list = cfg.palettes || [];
 
-    function apply(name) {
-        if (name === 'green') {
-            document.documentElement.setAttribute('data-palette', 'alt');
-        } else {
-            document.documentElement.removeAttribute('data-palette');
-        }
+    function entry(key) {
+        for (var i = 0; i < list.length; i++) { if (list[i].key === key) return list[i]; }
+        return null;
     }
 
-    // Saved choice wins over the config default.
+    function apply(key) {
+        var e = entry(key) || list[0];
+        if (!e) return;
+        if (e.attr) document.documentElement.setAttribute('data-palette', e.attr);
+        else        document.documentElement.removeAttribute('data-palette');
+    }
+
+    // Resolve starting palette: saved choice wins, else config default.
     var saved = localStorage.getItem('palette');
-    if (saved === 'alt') saved = 'green';          // legacy value support
-    if (saved === 'default') saved = 'indigo';     // legacy value support
+    if (saved === 'alt')     saved = 'green';    // legacy value support
+    if (saved === 'default') saved = 'indigo';   // legacy value support
+    var startKey = (entry(saved) ? saved : cfg.defaultPalette) || (list[0] && list[0].key);
 
-    apply(saved || cfg.defaultPalette || 'indigo');
+    apply(startKey);
+    window.__themeState = { current: startKey };
 
-    // Shared helper used by the toggle button in main.js / aggregate.js
-    window.__applyPalette = function (name) {
-        apply(name);
-        localStorage.setItem('palette', name);
+    // Set a palette by key (used internally + by future controls)
+    window.__applyPalette = function (key) {
+        apply(key);
+        localStorage.setItem('palette', key);
+        window.__themeState.current = key;
+    };
+
+    // Advance to the next palette in the list; returns the new entry.
+    window.__cyclePalette = function () {
+        var idx = 0;
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].key === window.__themeState.current) { idx = i; break; }
+        }
+        var next = list[(idx + 1) % list.length];
+        window.__applyPalette(next.key);
+        return next;
+    };
+
+    // Human-readable label for the current (or given) palette key.
+    window.__paletteLabel = function (key) {
+        var e = entry(key || window.__themeState.current);
+        return e ? e.label : (key || '');
     };
 })();

--- a/public/src/js/theme-config.js
+++ b/public/src/js/theme-config.js
@@ -1,0 +1,48 @@
+/* =====================================================================
+   THEME CONFIG  —  behaviour settings (edit the values in CONFIG below)
+   ---------------------------------------------------------------------
+   The actual COLOURS live in  src/css/theme.css.
+   This file decides WHICH palette is shown and whether visitors can
+   switch it. It is loaded in the <head> of every page so the choice is
+   applied before the first paint (no colour flash).
+   ===================================================================== */
+
+window.SITE_THEME = {
+    /* Palette shown to first-time visitors (before they pick one):
+         'green'  → Castleton green   (theme.css [data-palette="alt"])
+         'indigo' → original indigo   (theme.css :root)                  */
+    defaultPalette: 'green',
+
+    /* Show the palette switch button in the navbar?  true | false       */
+    enablePaletteToggle: true,
+};
+
+/* ---------------------------------------------------------------------
+   Internals — no need to edit below this line.
+   Applies the resolved palette immediately (runs before <body> paints)
+   and exposes window.__applyPalette() for the navbar toggle button.
+   --------------------------------------------------------------------- */
+(function () {
+    var cfg = window.SITE_THEME || {};
+
+    function apply(name) {
+        if (name === 'green') {
+            document.documentElement.setAttribute('data-palette', 'alt');
+        } else {
+            document.documentElement.removeAttribute('data-palette');
+        }
+    }
+
+    // Saved choice wins over the config default.
+    var saved = localStorage.getItem('palette');
+    if (saved === 'alt') saved = 'green';          // legacy value support
+    if (saved === 'default') saved = 'indigo';     // legacy value support
+
+    apply(saved || cfg.defaultPalette || 'indigo');
+
+    // Shared helper used by the toggle button in main.js / aggregate.js
+    window.__applyPalette = function (name) {
+        apply(name);
+        localStorage.setItem('palette', name);
+    };
+})();


### PR DESCRIPTION
## Summary

Introduces a full palette architecture and makes **Castleton green** the default theme, replacing the previous indigo-only design. Adds 5 experimental palette variants and a live palette-cycle toggle in the navbar.

---

## Changes

### Architecture
- **Split palette config** into two files:
  - `public/src/css/theme.css` — all colour token values (single source of truth)
  - `public/src/js/theme-config.js` — behaviour (default palette, toggle visibility, palette list)
- `style.css` `@import`s `theme.css` first; all components consume CSS variables only

### Castleton Green palette (default)
- Primary: `#0a5c36` Castleton green → dark `#0f5132`
- Accent-text token `--accent-text: #15803d` for date badges, company/institution labels
- **Per-palette dark mode**: deep-green surfaces (`#0a1f15`) instead of slate-blue bleed-through

### Parametrized dark mode
- Added `--surface` and `--nav-bg` tokens to `[data-theme="dark"]`
- Navbar and all card backgrounds use `var(--surface)` / `rgba(var(--nav-bg), ...)` — no more hardcoded hex

### Palette toggle
- Navbar swatch button shows the **live primary colour** of the active palette
- Click cycles: Castleton Green → Deep Forest → Emerald Noir → Sea Patina → Hunter Green → Jade Obsidian → Indigo
- Tooltip shows active palette name; persisted to localStorage

### 5 experimental palettes
| Key | Label | Primary |
|-----|-------|---------|
| `forest` | Deep Forest Metallic | `#2e5d4f` sea moss + metallic-gold edu accent |
| `emerald` | Emerald Noir | `#1b6b52` + mint glow |
| `patina` | Sea Patina | `#2f6f65` oxidised green |
| `hunter` | Hunter Chrome | `#2a4a33` + chrome muted |
| `jade` | Jade Obsidian | `#1f5f4a` jewel jade + warm-brass edu accent |

Each palette has a matching `[data-theme="dark"][data-palette="X"]` block.

### Fixes
- Education period badge now shares the same `#15803d` green as the institution label (was teal `#0d9488`)
- Hero subtitle enlarged: `clamp(1.35rem, 2.6vw, 1.7rem)`

---

## Testing
- `npx serve public -l 3000` — all 7 palettes cycle correctly in light and dark mode
- No CSS errors (`get_errors` clean across all 5 modified files)
- PR is conflict-free (rebased onto current main)