### PR TITLE
feat(theme): 7-palette cycler, live swatch, per-palette dark mode

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1359,20 +1359,20 @@ a.logo { text-decoration: none; }
 }
 
 .palette-toggle {
-    background: none;
-    border: 1px solid rgba(var(--primary-rgb), 0.2);
-    border-radius: var(--radius-sm);
+    background: var(--primary-color);
+    border: 2px solid rgba(255, 255, 255, 0.75);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
+    border-radius: 50%;
     width: 34px; height: 34px;
-    display: flex; align-items: center; justify-content: center;
+    padding: 0;
     cursor: pointer;
-    font-size: 0.85rem;
-    transition: background var(--transition), border-color var(--transition), transform var(--transition);
+    font-size: 0;            /* hide any text node — the colour is the indicator */
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
     line-height: 1; flex-shrink: 0;
 }
 .palette-toggle:hover {
-    background: rgba(var(--primary-rgb), 0.08);
-    border-color: rgba(var(--primary-rgb), 0.4);
-    transform: scale(1.1);
+    transform: scale(1.12);
+    box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.35);
 }
 
 /* =============================================
@@ -1527,6 +1527,8 @@ a.logo { text-decoration: none; }
     --bg-primary: #0f172a;
     --bg-secondary: #1e293b;
     --bg-dark: #020617;
+    --surface: #1e293b;        /* card surface — overridden per palette */
+    --nav-bg: 15, 23, 42;      /* navbar bg channels — overridden per palette */
     --shadow-card: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 1px rgba(var(--primary-rgb),0.15);
     --shadow: 0 4px 16px rgba(0,0,0,0.4);
     --shadow-hover: 0 12px 36px rgba(var(--primary-rgb),0.35), 0 4px 12px rgba(0,0,0,0.4);
@@ -1537,24 +1539,24 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
                 border-color 0.3s ease, box-shadow 0.3s ease;
 }
 [data-theme="dark"] body { background: var(--bg-primary); color: var(--text-primary); }
-[data-theme="dark"] .navbar { background: rgba(15,23,42,0.88) !important; border-bottom-color: rgba(var(--primary-rgb),0.15); }
-[data-theme="dark"] .navbar.scrolled { background: rgba(15,23,42,0.98) !important; box-shadow: 0 2px 20px rgba(0,0,0,0.3) !important; }
+[data-theme="dark"] .navbar { background: rgba(var(--nav-bg),0.88) !important; border-bottom-color: rgba(var(--primary-rgb),0.15); }
+[data-theme="dark"] .navbar.scrolled { background: rgba(var(--nav-bg),0.98) !important; box-shadow: 0 2px 20px rgba(0,0,0,0.3) !important; }
 [data-theme="dark"] .nav-links a { color: var(--text-secondary); }
 [data-theme="dark"] .nav-links a:hover,
 [data-theme="dark"] .nav-links a.active { color: var(--primary-color); background: rgba(var(--primary-rgb),0.12); }
 [data-theme="dark"] .theme-toggle { border-color: rgba(var(--primary-rgb),0.25); color: var(--text-secondary); }
 [data-theme="dark"] .about { background: var(--bg-secondary); }
-[data-theme="dark"] .skill-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
+[data-theme="dark"] .skill-card { background: var(--surface); border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .skill-card p { color: var(--text-secondary); }
 [data-theme="dark"] .about-text { color: var(--text-secondary); }
-[data-theme="dark"] .timeline-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
+[data-theme="dark"] .timeline-content { background: var(--surface); border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .timeline-title { color: var(--text-primary); }
-[data-theme="dark"] .blog-card { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
+[data-theme="dark"] .blog-card { background: var(--surface); border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .blog-title { color: var(--text-primary); }
 [data-theme="dark"] .blog-excerpt { color: var(--text-secondary); }
 [data-theme="dark"] .blog-meta { border-top-color: rgba(255,255,255,0.07); color: var(--text-light); }
 [data-theme="dark"] .education-section { background: var(--bg-secondary); }
-[data-theme="dark"] .education-content { background: #1e293b; border-color: rgba(var(--primary-rgb),0.14); }
+[data-theme="dark"] .education-content { background: var(--surface); border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .education-info h3 { color: var(--text-primary); }
 [data-theme="dark"] .institution { color: var(--accent-text); }
 [data-theme="dark"] .highlight-item { background: rgba(var(--primary-rgb),0.1); color: var(--text-secondary); }

--- a/public/src/css/theme.css
+++ b/public/src/css/theme.css
@@ -68,7 +68,7 @@
     --secondary-rgb:  20,  69,  47;   /* #14452f */
     --accent-rgb:     16, 185, 129;   /* #10b981 emerald — keeps tints visible */
     --mid-rgb:        21, 128,  61;   /* #15803d — lightened so date badges read brighter */
-    --edu-start-rgb:  13, 148, 136;   /* #0d9488 teal — variety in education */
+    --edu-start-rgb:  21, 128,  61;   /* #15803d — matches --accent-text so institution name & badge share the same green */
 
     /* Gradients auto-derive from the tokens above */
     --gradient:          linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
@@ -80,4 +80,134 @@
     --gradient-blog-1:   linear-gradient(135deg, var(--primary-color) 0%, rgb(var(--mid-rgb)) 100%);
     --gradient-blog-2:   linear-gradient(135deg, #0ea5e9 0%, var(--primary-color) 100%);
     --gradient-blog-5:   linear-gradient(135deg, rgb(var(--accent-rgb)) 0%, var(--secondary-color) 100%);
+}
+
+/* Castleton green — matching deep-green dark-mode backgrounds */
+[data-theme="dark"][data-palette="alt"] {
+    --bg-primary:   #0a1f15;
+    --bg-secondary: #102a1c;
+    --bg-dark:      #051009;
+    --surface:      #14301f;
+    --nav-bg:       10, 31, 21;
+    --accent-text:  #4ade80;   /* brighter label green for dark bg */
+}
+
+/* =====================================================================
+   EXPERIMENTAL EXTRA PALETTES  (selectable via the navbar swatch)
+   ---------------------------------------------------------------------
+   Each block only overrides the ~10 colour tokens — every gradient,
+   shadow and tint AUTO-DERIVES from them (the gradient definitions in
+   :root resolve var() lazily against the active palette).
+   Each green palette has a paired dark-mode block giving it matching
+   deep-green backgrounds instead of the default slate.
+   ===================================================================== */
+
+/* 1 — Deep Forest Metallic (moss green + metallic-gold education accent) */
+[data-palette="forest"] {
+    --primary-color:   #2e5d4f;   /* sea moss */
+    --primary-dark:    #1f4034;
+    --secondary-color: #16352d;   /* deep pine */
+    --accent-color:    #7fb295;   /* sage highlight */
+    --accent-text:     #2e6b50;   /* label green on white (~5:1) */
+    --primary-rgb:     46,  93,  79;
+    --secondary-rgb:   22,  53,  45;
+    --accent-rgb:     127, 178, 149;   /* sage */
+    --mid-rgb:         53, 112,  86;   /* readable mid for badges */
+    --edu-start-rgb:  197, 165, 114;   /* metallic gold */
+}
+[data-theme="dark"][data-palette="forest"] {
+    --bg-primary:   #0b1f1a;
+    --bg-secondary: #13312b;
+    --bg-dark:      #060f0c;
+    --surface:      #16352d;
+    --nav-bg:       11, 31, 26;
+    --accent-text:  #9ccbae;
+}
+
+/* 2 — Emerald Noir (sleek SaaS emerald + mint glow) */
+[data-palette="emerald"] {
+    --primary-color:   #1b6b52;   /* emerald */
+    --primary-dark:    #124a39;
+    --secondary-color: #0f2a22;
+    --accent-color:    #3ddc97;   /* mint shine */
+    --accent-text:     #047857;
+    --primary-rgb:     27, 107,  82;
+    --secondary-rgb:   15,  42,  34;
+    --accent-rgb:      61, 220, 151;   /* mint */
+    --mid-rgb:         24, 120,  90;
+    --edu-start-rgb:   13, 148, 136;   /* teal */
+}
+[data-theme="dark"][data-palette="emerald"] {
+    --bg-primary:   #08120f;
+    --bg-secondary: #0f2a22;
+    --bg-dark:      #050b09;
+    --surface:      #123026;
+    --nav-bg:       8, 18, 15;
+    --accent-text:  #3ddc97;
+}
+
+/* 3 — Dark Sea Patina (oxidised sea-green, editorial) */
+[data-palette="patina"] {
+    --primary-color:   #2f6f65;   /* sea green */
+    --primary-dark:    #1f4d46;
+    --secondary-color: #14302e;
+    --accent-color:    #6fb3a8;   /* patina mist */
+    --accent-text:     #2a665d;
+    --primary-rgb:     47, 111, 101;
+    --secondary-rgb:   20,  48,  46;
+    --accent-rgb:     111, 179, 168;   /* patina mist */
+    --mid-rgb:         45, 117, 105;
+    --edu-start-rgb:   47, 143, 127;
+}
+[data-theme="dark"][data-palette="patina"] {
+    --bg-primary:   #0a1818;
+    --bg-secondary: #14302e;
+    --bg-dark:      #050d0d;
+    --surface:      #173432;
+    --nav-bg:       10, 24, 24;
+    --accent-text:  #6fb3a8;
+}
+
+/* 4 — Hunter Chrome (deep hunter green + chrome muted) */
+[data-palette="hunter"] {
+    --primary-color:   #2a4a33;   /* hunter green */
+    --primary-dark:    #1c3324;
+    --secondary-color: #1a2a1f;
+    --accent-color:    #8fa68e;   /* chrome muted */
+    --accent-text:     #44734f;
+    --primary-rgb:     42,  74,  51;
+    --secondary-rgb:   26,  42,  31;
+    --accent-rgb:     143, 166, 142;   /* chrome */
+    --mid-rgb:         58,  90,  68;
+    --edu-start-rgb:  105, 130, 105;
+}
+[data-theme="dark"][data-palette="hunter"] {
+    --bg-primary:   #0d1410;
+    --bg-secondary: #1a2a1f;
+    --bg-dark:      #070b08;
+    --surface:      #1d2e22;
+    --nav-bg:       13, 20, 16;
+    --accent-text:  #b6c7b0;
+}
+
+/* 5 — Jade Obsidian (jewel jade + warm-brass education accent) */
+[data-palette="jade"] {
+    --primary-color:   #1f5f4a;   /* jade */
+    --primary-dark:    #154235;
+    --secondary-color: #102a22;
+    --accent-color:    #46c2a0;   /* bright jade */
+    --accent-text:     #15795a;
+    --primary-rgb:     31,  95,  74;
+    --secondary-rgb:   16,  42,  34;
+    --accent-rgb:      70, 194, 160;   /* bright jade */
+    --mid-rgb:         31, 115,  89;
+    --edu-start-rgb:  168, 137, 107;   /* warm brass */
+}
+[data-theme="dark"][data-palette="jade"] {
+    --bg-primary:   #06100d;
+    --bg-secondary: #102a22;
+    --bg-dark:      #040a08;
+    --surface:      #133026;
+    --nav-bg:       6, 16, 13;
+    --accent-text:  #46c2a0;
 }

--- a/public/src/js/aggregate.js
+++ b/public/src/js/aggregate.js
@@ -344,14 +344,15 @@ function setupPaletteToggle() {
         btn.style.display = 'none';
         return;
     }
-    const setIcon = (isGreen) => {
-        btn.textContent = isGreen ? '🟣' : '🟢';
-        btn.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+    const sync = () => {
+        btn.textContent = '';
+        const label = window.__paletteLabel ? window.__paletteLabel() : '';
+        btn.title = label ? `Theme: ${label} — click to change` : 'Change colour theme';
+        btn.setAttribute('aria-label', label ? `Colour theme: ${label}. Click to change.` : 'Change colour theme');
     };
-    setIcon(document.documentElement.hasAttribute('data-palette'));
+    sync();
     btn.addEventListener('click', () => {
-        const next = document.documentElement.hasAttribute('data-palette') ? 'indigo' : 'green';
-        window.__applyPalette(next);
-        setIcon(next === 'green');
+        if (window.__cyclePalette) window.__cyclePalette();
+        sync();
     });
 }

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -146,21 +146,22 @@ themeToggle?.addEventListener('click', () => {
     setThemeIcon(next === 'dark');
 });
 
-// ── Palette toggle ──
+// ── Palette swatch (cycles through palettes) ──
 const paletteToggle = document.getElementById('paletteToggle');
 if (paletteToggle) {
     if (window.SITE_THEME && window.SITE_THEME.enablePaletteToggle === false) {
         paletteToggle.style.display = 'none';
     } else {
-        const setPaletteIcon = (isGreen) => {
-            paletteToggle.textContent = isGreen ? '🟣' : '🟢';
-            paletteToggle.setAttribute('aria-label', isGreen ? 'Switch to indigo palette' : 'Switch to green palette');
+        const syncPalette = () => {
+            paletteToggle.textContent = '';
+            const label = window.__paletteLabel ? window.__paletteLabel() : '';
+            paletteToggle.title = label ? `Theme: ${label} — click to change` : 'Change colour theme';
+            paletteToggle.setAttribute('aria-label', label ? `Colour theme: ${label}. Click to change.` : 'Change colour theme');
         };
-        setPaletteIcon(document.documentElement.hasAttribute('data-palette'));
+        syncPalette();
         paletteToggle.addEventListener('click', () => {
-            const next = document.documentElement.hasAttribute('data-palette') ? 'indigo' : 'green';
-            window.__applyPalette(next);
-            setPaletteIcon(next === 'green');
+            if (window.__cyclePalette) window.__cyclePalette();
+            syncPalette();
         });
     }
 }

--- a/public/src/js/theme-config.js
+++ b/public/src/js/theme-config.js
@@ -2,15 +2,28 @@
    THEME CONFIG  —  behaviour settings (edit the values in CONFIG below)
    ---------------------------------------------------------------------
    The actual COLOURS live in  src/css/theme.css.
-   This file decides WHICH palette is shown and whether visitors can
-   switch it. It is loaded in the <head> of every page so the choice is
-   applied before the first paint (no colour flash).
+   This file decides WHICH palettes exist, which one is the default, and
+   whether visitors can switch. Loaded in the <head> of every page so the
+   choice is applied before first paint (no colour flash).
    ===================================================================== */
 
 window.SITE_THEME = {
-    /* Palette shown to first-time visitors (before they pick one):
-         'green'  → Castleton green   (theme.css [data-palette="alt"])
-         'indigo' → original indigo   (theme.css :root)                  */
+    /* Palettes the navbar swatch cycles through, in order.
+         key   → identifier saved to localStorage
+         label → shown in the button tooltip
+         attr  → the data-palette attribute value
+                 (null  = the default :root palette, i.e. Indigo)        */
+    palettes: [
+        { key: 'green',   label: 'Castleton Green', attr: 'alt' },
+        { key: 'forest',  label: 'Deep Forest',     attr: 'forest' },
+        { key: 'emerald', label: 'Emerald Noir',    attr: 'emerald' },
+        { key: 'patina',  label: 'Sea Patina',      attr: 'patina' },
+        { key: 'hunter',  label: 'Hunter Green',    attr: 'hunter' },
+        { key: 'jade',    label: 'Jade Obsidian',   attr: 'jade' },
+        { key: 'indigo',  label: 'Indigo',          attr: null },
+    ],
+
+    /* Palette shown to first-time visitors (must be a key above).       */
     defaultPalette: 'green',
 
     /* Show the palette switch button in the navbar?  true | false       */
@@ -20,29 +33,54 @@ window.SITE_THEME = {
 /* ---------------------------------------------------------------------
    Internals — no need to edit below this line.
    Applies the resolved palette immediately (runs before <body> paints)
-   and exposes window.__applyPalette() for the navbar toggle button.
+   and exposes helpers used by the navbar swatch in main.js/aggregate.js.
    --------------------------------------------------------------------- */
 (function () {
-    var cfg = window.SITE_THEME || {};
+    var cfg  = window.SITE_THEME || {};
+    var list = cfg.palettes || [];
 
-    function apply(name) {
-        if (name === 'green') {
-            document.documentElement.setAttribute('data-palette', 'alt');
-        } else {
-            document.documentElement.removeAttribute('data-palette');
-        }
+    function entry(key) {
+        for (var i = 0; i < list.length; i++) { if (list[i].key === key) return list[i]; }
+        return null;
     }
 
-    // Saved choice wins over the config default.
+    function apply(key) {
+        var e = entry(key) || list[0];
+        if (!e) return;
+        if (e.attr) document.documentElement.setAttribute('data-palette', e.attr);
+        else        document.documentElement.removeAttribute('data-palette');
+    }
+
+    // Resolve starting palette: saved choice wins, else config default.
     var saved = localStorage.getItem('palette');
-    if (saved === 'alt') saved = 'green';          // legacy value support
-    if (saved === 'default') saved = 'indigo';     // legacy value support
+    if (saved === 'alt')     saved = 'green';    // legacy value support
+    if (saved === 'default') saved = 'indigo';   // legacy value support
+    var startKey = (entry(saved) ? saved : cfg.defaultPalette) || (list[0] && list[0].key);
 
-    apply(saved || cfg.defaultPalette || 'indigo');
+    apply(startKey);
+    window.__themeState = { current: startKey };
 
-    // Shared helper used by the toggle button in main.js / aggregate.js
-    window.__applyPalette = function (name) {
-        apply(name);
-        localStorage.setItem('palette', name);
+    // Set a palette by key (used internally + by future controls)
+    window.__applyPalette = function (key) {
+        apply(key);
+        localStorage.setItem('palette', key);
+        window.__themeState.current = key;
+    };
+
+    // Advance to the next palette in the list; returns the new entry.
+    window.__cyclePalette = function () {
+        var idx = 0;
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].key === window.__themeState.current) { idx = i; break; }
+        }
+        var next = list[(idx + 1) % list.length];
+        window.__applyPalette(next.key);
+        return next;
+    };
+
+    // Human-readable label for the current (or given) palette key.
+    window.__paletteLabel = function (key) {
+        var e = entry(key || window.__themeState.current);
+        return e ? e.label : (key || '');
     };
 })();


### PR DESCRIPTION
## Summary

Extends the green palette system from PR #18 with a full 7-palette cycler, live colour swatch button, and per-palette dark-mode backgrounds.

---

## Changes

### 5 experimental palettes (theme.css)
| Key | Label | Primary |
|-----|-------|---------|
| `forest` | Deep Forest Metallic | `#2e5d4f` sea moss + metallic-gold edu accent |
| `emerald` | Emerald Noir | `#1b6b52` + mint glow |
| `patina` | Sea Patina | `#2f6f65` oxidised green |
| `hunter` | Hunter Chrome | `#2a4a33` + chrome muted |
| `jade` | Jade Obsidian | `#1f5f4a` jewel jade + warm-brass edu accent |

Each palette has a matching `[data-theme="dark"][data-palette="X"]` block giving it deep-green surfaces instead of default slate.

### Live colour swatch (style.css)
- `.palette-toggle` is now a filled circle showing the active `--primary-color`
- Hover shows a matching ring shadow; no text/emoji needed — the colour is the indicator

### Parametrized dark mode (style.css)
- Added `--surface` and `--nav-bg` CSS tokens to `[data-theme="dark"]`
- Navbar and all card backgrounds (`.skill-card`, `.timeline-content`, `.blog-card`, `.education-content`) now use `var(--surface)` — no hardcoded `#1e293b`

### Palette cycler (theme-config.js, main.js, aggregate.js)
- `window.SITE_THEME.palettes`: ordered list of `{key, label, attr}` — 7 entries
- `window.__cyclePalette()`: advances to next palette, returns new entry
- `window.__applyPalette(key)`: jump to palette by key
- `window.__paletteLabel(key?)`: human-readable name for tooltip
- Legacy localStorage values (`'alt'`→`'green'`, `'default'`→`'indigo'`) mapped for backward compat

### Fix: education badge colour (theme.css)
- `--edu-start-rgb` changed from `13,148,136` (teal) to `21,128,61` (`#15803d`) so the period badge gradient matches the institution label colour

---

## Testing
- `npx serve public -l 3000` — all 7 palettes cycle in light and dark mode
- No CSS/JS errors
- Single clean commit on top of main — no conflicts