### PR TITLE
docs(theme): version comment v2.0.0 on theme.css

### DIFF
--- a/public/src/css/theme.css
+++ b/public/src/css/theme.css
@@ -1,5 +1,5 @@
 /* =====================================================================
-   THEME — COLOUR PALETTES
+   THEME — COLOUR PALETTES                                  v2.0.0
    ---------------------------------------------------------------------
    This is the single place to edit colours or add new palettes.
    It is pulled into style.css via:   @import url('theme.css');


### PR DESCRIPTION
Minor housekeeping — bumps the file-header version comment in `theme.css` to `v2.0.0` following the palette system shipped in PRs #18 and #20.

No functional changes.