### PR TITLE
fix: dark mode toggle + theme.css housekeeping

### DIFF
--- a/public/src/css/theme.css
+++ b/public/src/css/theme.css
@@ -1,5 +1,5 @@
 /* =====================================================================
-   THEME — COLOUR PALETTES
+   THEME — COLOUR PALETTES                                  v2.0.0
    ---------------------------------------------------------------------
    This is the single place to edit colours or add new palettes.
    It is pulled into style.css via:   @import url('theme.css');

--- a/public/src/js/aggregate.js
+++ b/public/src/js/aggregate.js
@@ -331,10 +331,26 @@ if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
         init();
         setupPaletteToggle();
+        setupThemeToggle();
     });
 } else {
     init();
     setupPaletteToggle();
+    setupThemeToggle();
+}
+
+function setupThemeToggle() {
+    const btn = document.getElementById('themeToggle');
+    if (!btn) return;
+    const sync = (isDark) => { btn.textContent = isDark ? '☀️' : '🌙'; };
+    sync(document.documentElement.getAttribute('data-theme') === 'dark');
+    btn.addEventListener('click', () => {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const next = isDark ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        localStorage.setItem('theme', next);
+        sync(next === 'dark');
+    });
 }
 
 function setupPaletteToggle() {


### PR DESCRIPTION
## Changes

### fix: dark mode toggle not working on homepage (`aggregate.js`)
The `index.html` page loads `aggregate.js` (not `main.js`), but the dark mode click handler only existed in `main.js`. Added `setupThemeToggle()` to `aggregate.js` — same logic: reads `data-theme`, toggles on click, persists to `localStorage`, syncs the ☀️/🌙 icon.

### docs: theme.css version comment bumped to v2.0.0
Minor housekeeping following the palette system shipped in PRs #18 and #20.