### PR TITLE
fix(dark): hide education card separator lines in dark mode

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1559,6 +1559,8 @@ body, .navbar, .skill-card, .timeline-content, .blog-card,
 [data-theme="dark"] .education-content { background: var(--surface); border-color: rgba(var(--primary-rgb),0.14); }
 [data-theme="dark"] .education-info h3 { color: var(--text-primary); }
 [data-theme="dark"] .institution { color: var(--accent-text); }
+[data-theme="dark"] .education-details { border-bottom-color: rgba(255,255,255,0.07); }
+[data-theme="dark"] .education-highlights { border-top-color: rgba(255,255,255,0.07); }
 [data-theme="dark"] .highlight-item { background: rgba(var(--primary-rgb),0.1); color: var(--text-secondary); }
 [data-theme="dark"] .detail-item { color: var(--text-secondary); }
 [data-theme="dark"] .section-title { color: var(--text-primary); }


### PR DESCRIPTION
The divider lines inside education cards (`.education-details` border-bottom and `.education-highlights` border-top) used hardcoded `#e5e7eb` (light grey) with no dark-mode override, making them appear as bright white stripes.\n\nAdds two dark-mode rules to fade them to `rgba(255,255,255,0.07)` — matching the same subtle separator used elsewhere in dark mode.