### PR TITLE
docs(readme): document theme system, dark mode, new pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A fast, static portfolio site for AI/ML & MLOps work. Built with plain **HTML/CSS/JS**, deployed as a **Static Site** on Render with pretty URLs, SEO basics, and a no-backend contact form via **Formspree**. Helped to setup your own website? You can buy me a coffee to support my work ☕️.
 
-- © 2025 Mukharbek Organokov  
+- © 2025–2026 Mukharbek Organokov  
 - 🌐 Website: [www.organokov.com](https://www.organokov.com)  
 - 📜 License: GNU General Public License v3.0  
 
@@ -16,22 +16,29 @@ A fast, static portfolio site for AI/ML & MLOps work. Built with plain **HTML/CS
     ├── package-lock.json              # Exact, locked dependency versions for reproducible installs
     ├── package.json                   # Project metadata + dev scripts (e.g., "dev" with `serve`)
     ├── public/                        # All files served to the browser (site root)
-    │  ├── assets/                     # Images, icons, downloadable files, etc.
+    │  ├── assets/                     # Images, icons, downloadable files
+    │  │  ├── cv.pdf                   # Downloadable CV
+    │  │  ├── favicon.svg              # Site favicon
+    │  │  └── og-card.svg              # Open Graph / social share card
     │  ├── about.html                  # About page (also reachable at /about via Render rewrites)
     │  ├── experience.html             # Experience/Resume page
-    │  ├── education.html              # Education page   
+    │  ├── education.html              # Education page
     │  ├── blog.html                   # Blog landing page (or list of posts)
     │  ├── contact.html                # Contact page (Formspree form lives here)
+    │  ├── privacy.html                # Privacy notice (linked from the contact form)
     │  ├── index.html                  # Current homepage (also used as “shell” for aggregate loader)
     │  ├── index-old.html              # Previous homepage kept for reference (not linked)
     │  ├── 404.html                    # Custom not-found page (shown on broken routes)
     │  ├── robots.txt                  # Crawler rules; points to sitemap.xml
     │  ├── sitemap.xml                 # SEO sitemap of canonical “pretty” URLs
     │  └── src/                        # Versioned static assets (cache-busted by path)
-    │     ├── css/                     # Stylesheets (site-wide CSS, component styles)
+    │     ├── css/                     # Stylesheets
+    │     │  ├── style.css             # Site-wide layout + component styles (imports theme.css)
+    │     │  └── theme.css             # Colour palettes (single source of truth for colours)
     │     └── js/                      # JavaScript for UX and dynamic assembly
     │        ├── aggregate.js          # Fetches each page, extracts main sections, and mounts them
-    │        └── main.js               # Global UI (nav, animations) + delegated contact form handler
+    │        ├── main.js               # Global UI (nav, animations) + delegated contact form handler
+    │        └── theme-config.js       # Theme behaviour: default palette, toggle on/off, palette list
     ├── render.yml                     # Render Static Site blueprint (routes/rewrites + headers/caching)
     └── serve.json                     # Local dev config for `npx serve` (headers/spa/caching; optional)
 
@@ -40,9 +47,12 @@ A fast, static portfolio site for AI/ML & MLOps work. Built with plain **HTML/CS
 - **Static, zero-backend** (served from `/public`)
 - **Pretty URLs** (`/about`, `/experience`, `/blog` etc.) via Render rewrites
 - **Dynamic “aggregate” loader** that assembles sections into a single page
+- **Dark mode** with system-preference detection and a navbar toggle (persisted to `localStorage`, applied before first paint to avoid a flash)
+- **Config-driven colour palettes** — switch between Castleton Green and Indigo from the navbar; palettes and behaviour are defined in `theme.css` + `theme-config.js`
 - **Contact form** wired to **Formspree** (no server code by decision)
 - **Resilient UX:** custom `404.html`, smooth scrolling, mobile nav
-- **SEO essentials:** `sitemap.xml`, `robots.txt`, canonical tags
+- **Accessibility:** semantic landmarks, `aria-label`s on controls, keyboard-friendly nav
+- **SEO essentials:** `sitemap.xml`, `robots.txt`, canonical tags, Open Graph/Twitter cards
 - **Security & perf headers** via `render.yml` (HSTS, caching)
 
 ## Quick Start (Local)
@@ -135,6 +145,35 @@ Use root-relative links in HTML:
 <a href="/blog">Blog</a>
 <a href="/contact">Contact</a>
 ```
+
+## Theming (Dark Mode & Colour Palettes)
+
+Two independent axes control appearance, both set on the root `<html>` element **before first paint** (an inline IIFE + `theme-config.js` in every `<head>`), so there's no colour flash on load:
+
+- **Light / dark** → `data-theme="dark"` (toggled by the 🌙 button; defaults to the OS preference)
+- **Colour palette** → `data-palette="…"` (toggled by the navbar colour swatch)
+
+Colours and behaviour live in two files:
+
+| File | Responsibility |
+| --- | --- |
+| `public/src/css/theme.css` | All colour **values** — one CSS block per palette (`:root` = Indigo, `[data-palette="alt"]` = Castleton Green, plus a few commented-out experimental greens). `style.css` imports it first. |
+| `public/src/js/theme-config.js` | All colour **behaviour** — which palettes exist, the default, and whether the switch is shown. |
+
+Edit the `window.SITE_THEME` object in `theme-config.js`:
+
+```js
+window.SITE_THEME = {
+  palettes: [
+    { key: 'green',  label: 'Castleton Green', attr: 'alt'  },
+    { key: 'indigo', label: 'Indigo',          attr: null   }, // null = :root default
+  ],
+  defaultPalette: 'green',     // shown to first-time visitors
+  enablePaletteToggle: true,   // false hides the navbar swatch entirely
+};
+```
+
+To **add a palette**: copy a block in `theme.css` (e.g. `[data-palette="alt"]`), rename the selector, tweak the tokens, then add a matching `{ key, label, attr }` entry to the list above. To **lock the site to one colour**, set `enablePaletteToggle: false`.
 
 ## Deployment
 


### PR DESCRIPTION
Brings the README up to date with everything shipped since the redesign.

## Changes
- **Content tree** — adds `education.html`, `privacy.html`, `theme.css`, `theme-config.js`, and the `assets/` contents (`cv.pdf`, `favicon.svg`, `og-card.svg`)
- **Features** — documents dark mode, config-driven palettes, accessibility, and OG/Twitter cards
- **New 'Theming' section** — explains the two independent axes (`data-theme` for light/dark, `data-palette` for colour), the `theme.css` + `theme-config.js` split, and how to add/lock palettes
- **Copyright** — bumped to 2025–2026 to match the site footer