### PR TITLE
docs: add docs/ folder (ARCHITECTURE + CONTRIBUTING)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,20 @@ A fast, static portfolio site for AI/ML & MLOps work. Built with plain **HTML/CS
 - 🌐 Website: [www.organokov.com](https://www.organokov.com)  
 - 📜 License: GNU General Public License v3.0  
 
+## Documentation
+
+Deeper developer docs live in [`docs/`](docs/README.md):
+
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — how the site works: the dual-page model, the homepage aggregate loader, and the two-axis theming system.
+- [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) — local dev, the branch/PR workflow, and step-by-step guides (add a page, blog post, or palette).
+
 ## Content
 
     ├── README.md                      # Project overview, setup, deploy, and domain setup
+    ├── docs/                          # Developer documentation
+    │  ├── README.md                   # Docs index
+    │  ├── ARCHITECTURE.md             # How the site works (dual-page model, loader, theming)
+    │  └── CONTRIBUTING.md             # Local dev, PR workflow, how-to guides, checklist
     ├── package-lock.json              # Exact, locked dependency versions for reproducible installs
     ├── package.json                   # Project metadata + dev scripts (e.g., "dev" with `serve`)
     ├── public/                        # All files served to the browser (site root)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,251 @@
+# Architecture
+
+How this portfolio is put together and why. The site is intentionally a
+**plain static site** — no framework, no bundler, no build step — so the whole
+thing can be understood by reading a handful of files.
+
+- [Goals & constraints](#goals--constraints)
+- [The dual-page model](#the-dual-page-model)
+- [The aggregate loader](#the-aggregate-loader)
+- [Theming: two independent axes](#theming-two-independent-axes)
+- [File responsibilities](#file-responsibilities)
+- [Page lifecycle](#page-lifecycle)
+- [Routing & pretty URLs](#routing--pretty-urls)
+- [Known quirks & gotchas](#known-quirks--gotchas)
+
+---
+
+## Goals & constraints
+
+| Goal | Consequence |
+| --- | --- |
+| Fast first paint, no JS framework cost | Hand-written HTML/CSS/JS, served as-is |
+| Zero backend | Contact form posts to **Formspree**; no server code |
+| Good SEO & shareability | Every page is a real, crawlable HTML file with its own `<title>`, canonical tag, and Open Graph metadata |
+| Single-page feel on the homepage | A small loader stitches the section pages into one scrolling page |
+| No build step | Source files in `public/` are exactly what ships |
+
+The tension between "every page is a standalone document" (good for SEO) and
+"the homepage should feel like one continuous page" is resolved by the
+**dual-page model** below.
+
+---
+
+## The dual-page model
+
+Every content area exists as a **standalone HTML file** in `public/`:
+
+```
+about.html  experience.html  education.html  blog.html  contact.html
+```
+
+Each one:
+
+- is fully self-contained (own `<head>`, navbar, footer, metadata),
+- is reachable directly at a pretty URL (`/about`, `/experience`, …),
+- wraps its real content in a single `<main><section>…</section></main>`.
+
+The homepage [index.html](../public/index.html) is a thin **shell**. Instead of
+duplicating content, it contains an empty mount point:
+
+```html
+<main id="main">
+  <div class="loading" id="loading-indicator">Loading</div>
+  <div id="all-sections"></div>
+</main>
+<script src="/src/js/aggregate.js"></script>
+```
+
+At runtime, [aggregate.js](../public/src/js/aggregate.js) fetches each standalone
+page, extracts its `<main section>`, and appends it to `#all-sections` — turning
+six separate documents into one long scrolling homepage.
+
+```
+                       ┌── fetch about.html ──► extract <main section> ─┐
+index.html (shell) ────┼── fetch experience.html ──► …                  ├──► #all-sections
+  + aggregate.js       ├── fetch education.html ──► …                   │     (one page)
+                       ├── fetch blog.html ──► …                        │
+                       └── fetch contact.html ──► …                     ┘
+```
+
+The same HTML therefore serves two audiences:
+
+- **Crawlers / direct links** → the standalone page (`/about`).
+- **Homepage visitors** → the aggregated single-page experience (`/#about`).
+
+The sub-pages load [main.js](../public/src/js/main.js); the homepage shell loads
+[aggregate.js](../public/src/js/aggregate.js). Both share the same CSS and the
+same theme bootstrap.
+
+---
+
+## The aggregate loader
+
+[aggregate.js](../public/src/js/aggregate.js) drives the homepage. Key pieces:
+
+**1. The page manifest** — the ordered list of sections to stitch together:
+
+```js
+const pages = [
+  { id: 'home',       url: 'index.html',      title: 'Home' },
+  { id: 'about',      url: 'about.html',      title: 'About' },
+  { id: 'experience', url: 'experience.html', title: 'Experience' },
+  { id: 'education',  url: 'education.html',   title: 'Education' },
+  { id: 'blog',       url: 'blog.html',        title: 'Blog' },
+  { id: 'contact',    url: 'contact.html',     title: 'Contact' },
+];
+```
+
+**2. `fetchSection()`** — fetches a page, parses it with `DOMParser`, and pulls
+out the meaningful content:
+
+- `home` → the `.hero` block (with a hard-coded fallback if missing).
+- everything else → `main section` (falls back to the first `section`, then to
+  `main` with inline styles stripped).
+- on failure → a visible error card, so a broken page never blanks the site.
+
+**3. Progressive load** — the hero loads first and the loading indicator is
+hidden immediately; the remaining sections stream in sequentially so the page is
+interactive fast.
+
+**4. `setupSmoothScrolling()`** — an `IntersectionObserver` highlights the active
+nav link as you scroll; nav clicks smooth-scroll and update the hash with
+`history.replaceState` (not `pushState`), so the back button isn't polluted with
+one entry per section.
+
+**5. `setupInteractions()`** — wires up the post-load UI: fade-in animations,
+the navbar scroll effect, the mobile menu, the back-to-top button, and the blog
+"Read more / Show less" toggles.
+
+**6. Toggles** — `setupThemeToggle()` and `setupPaletteToggle()` wire the navbar
+🌙 dark-mode button and the colour swatch (see [Theming](#theming-two-independent-axes)).
+
+> Because the homepage content is injected **after** load, anything that touches
+> it (event handlers, the contact form) is bound with **event delegation** or
+> re-run inside `setupInteractions()`. A handler bound only on `DOMContentLoaded`
+> to a specific element would miss the injected markup.
+
+---
+
+## Theming: two independent axes
+
+Appearance is controlled by **two orthogonal attributes** on the root `<html>`
+element, each persisted to `localStorage` and applied **before first paint** to
+avoid a flash of the wrong colours.
+
+| Axis | Attribute | Values | Toggle |
+| --- | --- | --- | --- |
+| Light / dark | `data-theme` | `dark` (absent = light) | 🌙 navbar button |
+| Colour palette | `data-palette` | `alt` (Castleton Green), absent = `:root` Indigo | colour swatch |
+
+**Where the values live:**
+
+- [public/src/css/theme.css](../public/src/css/theme.css) — **colour values only**.
+  One block per palette (`:root`, `[data-palette="alt"]`, plus commented-out
+  experimental greens), and per-palette dark-mode overrides
+  (`[data-theme="dark"][data-palette="alt"]`). All gradients/tints auto-derive
+  from a small set of `--*-rgb` channel tokens, so a palette only needs to
+  redefine ~10 variables.
+- [public/src/js/theme-config.js](../public/src/js/theme-config.js) — **behaviour
+  only**: which palettes exist (`window.SITE_THEME.palettes`), the default, and
+  whether the swatch is shown (`enablePaletteToggle`). It exposes
+  `__applyPalette()`, `__cyclePalette()`, and `__paletteLabel()` for the toggle.
+
+**Pre-paint bootstrap** — every page's `<head>` contains, in order:
+
+```html
+<!-- 1. dark/light, inline so it runs before CSS applies -->
+<script>!function(){var t=localStorage.getItem('theme');t?document.documentElement.setAttribute('data-theme',t):window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement.setAttribute('data-theme','dark')}();</script>
+<!-- 2. palette, sets data-palette before <body> paints -->
+<script src="/src/js/theme-config.js"></script>
+```
+
+This is why there's no colour flicker on reload: the attributes are set before
+the browser renders the first frame.
+
+See the **Theming** section of the [root README](../README.md) for the
+copy-paste config and instructions to add or lock a palette.
+
+---
+
+## File responsibilities
+
+| File | Responsibility |
+| --- | --- |
+| [public/index.html](../public/index.html) | Homepage **shell** — empty mount + `aggregate.js` |
+| `public/{about,experience,education,blog,contact,privacy}.html` | Standalone pages; content lives in `<main><section>` |
+| [public/404.html](../public/404.html) | Custom not-found page (`noindex`) |
+| [public/src/css/style.css](../public/src/css/style.css) | Layout + component styles; `@import`s `theme.css` first |
+| [public/src/css/theme.css](../public/src/css/theme.css) | All colour values; one block per palette |
+| [public/src/js/aggregate.js](../public/src/js/aggregate.js) | Homepage loader + all homepage interactions |
+| [public/src/js/main.js](../public/src/js/main.js) | Sub-page UI + delegated contact-form handler |
+| [public/src/js/theme-config.js](../public/src/js/theme-config.js) | Palette list, default, toggle behaviour |
+| [render.yml](../render.yml) | Render blueprint: rewrites, security + cache headers |
+| [serve.json](../serve.json) | Local `npx serve` config (optional) |
+
+---
+
+## Page lifecycle
+
+**Direct visit to a sub-page (`/about`)**
+
+```
+Render rewrite /about → /about.html
+  └─ <head> inline IIFE sets data-theme        (no flash)
+  └─ theme-config.js sets data-palette         (no flash)
+  └─ style.css + theme.css paint
+  └─ main.js wires nav, toggles, blog/contact handlers
+```
+
+**Visit to the homepage (`/`)**
+
+```
+index.html shell paints (theme set in <head>, same as above)
+  └─ aggregate.js runs
+       ├─ strips any stale #hash (fresh loads start at top)
+       ├─ fetch index.html → mount .hero, hide loader
+       ├─ fetch about/experience/education/blog/contact → mount <section>s
+       ├─ setupSmoothScrolling()  (scroll-spy nav, replaceState hash)
+       ├─ setupInteractions()     (fade-in, mobile menu, back-to-top, blog toggles)
+       ├─ setupPaletteToggle()    (colour swatch)
+       └─ setupThemeToggle()      (🌙 dark mode)
+```
+
+---
+
+## Routing & pretty URLs
+
+Pages are plain files but served at clean paths via **Render rewrites** in
+[render.yml](../render.yml):
+
+```yaml
+routes:
+  - { type: rewrite, source: /about,   destination: /about.html }
+  - { type: rewrite, source: /education, destination: /education.html }
+  - { type: rewrite, source: /privacy, destination: /privacy.html }
+  # …one per page
+```
+
+Always use **root-relative** links in HTML (`/about`, not `about.html`) so links
+work identically from any path. The same `render.yml` also sets security headers
+(HSTS, `X-Frame-Options`, `nosniff`, referrer policy) and caching — long/immutable
+for `/src/**` and `/assets/**`, short for `*.html`.
+
+---
+
+## Known quirks & gotchas
+
+- **Injected homepage content needs delegated handlers.** The contact form is
+  injected by the loader, so its submit handler is bound globally via delegation
+  in `main.js` (guarded by `window.__contactDelegatedBound`). Don't rebind it to
+  the element directly.
+- **Two JS entry points.** `main.js` (sub-pages) and `aggregate.js` (homepage)
+  duplicate a little logic on purpose (e.g. both have a theme toggle). If you
+  change a global behaviour, check **both** files — this is exactly why the dark
+  mode toggle once worked on sub-pages but not the homepage.
+- **Open Graph image path.** Pages reference `assets/og-card.png` while the file
+  in the repo is `og-card.svg`. Some scrapers don't render SVG OG images — add a
+  PNG (or update the `og:image` paths) if social previews matter.
+- **Adding a section to the homepage** means adding it to the `pages` array in
+  `aggregate.js` **and** creating the standalone page — the standalone file alone
+  won't appear on the homepage.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing
+
+A practical guide to working on this site. It's a static HTML/CSS/JS project —
+**no build step** — so the loop is fast: edit a file, refresh the browser.
+
+- [Prerequisites](#prerequisites)
+- [Local development](#local-development)
+- [Branch & PR workflow](#branch--pr-workflow)
+- [Commit conventions](#commit-conventions)
+- [Common tasks](#common-tasks)
+  - [Add a new page](#add-a-new-page)
+  - [Add a blog post](#add-a-blog-post)
+  - [Add or change a colour palette](#add-or-change-a-colour-palette)
+  - [Edit content that appears on the homepage](#edit-content-that-appears-on-the-homepage)
+- [Pre-merge checklist](#pre-merge-checklist)
+
+If you haven't yet, skim [ARCHITECTURE.md](ARCHITECTURE.md) first — most tasks
+below make more sense once you know the dual-page / aggregate-loader model.
+
+---
+
+## Prerequisites
+
+- **Node 18+** (only used to run a static file server)
+- `git` and the **GitHub CLI** (`gh`) if you want the one-line PR flow below
+
+---
+
+## Local development
+
+```bash
+npm ci                    # install the single dev dep (serve)
+npm run dev               # serve public/ at http://localhost:3000
+```
+
+Any static server works just as well:
+
+```bash
+npx serve public -l 3000
+python -m http.server -d public 3000
+```
+
+There is no compile step — what's in `public/` is exactly what ships. Edit and
+hard-refresh (⌘⇧R) to bypass the long cache headers during development.
+
+---
+
+## Branch & PR workflow
+
+Work on a short-lived branch and merge via a squashed PR (keeps `main` linear).
+
+```bash
+git checkout main && git pull
+git checkout -b <type>/<short-description>      # e.g. fix/education-dark-borders
+
+# …make changes…
+
+git add -A
+git commit -m "<type>(<scope>): <summary>"
+git push -u origin HEAD
+
+gh pr create --fill --base main                 # or pass --title/--body
+gh pr merge --squash --delete-branch
+```
+
+> **Heads-up on squash merges.** Because PRs are squash-merged, a feature branch's
+> individual commits won't exist on `main`. If you keep working on an old branch
+> after its PR merged, git history diverges and GitHub reports phantom conflicts.
+> The fix is to start fresh: `git checkout main && git pull && git checkout -b new/branch`.
+
+---
+
+## Commit conventions
+
+[Conventional Commits](https://www.conventionalcommits.org/) — `<type>(<scope>): <summary>`:
+
+| Type | Use for |
+| --- | --- |
+| `feat` | a new user-facing capability |
+| `fix` | a bug fix |
+| `docs` | documentation only |
+| `style` | formatting / CSS-only visual tweaks |
+| `refactor` | code change that neither fixes a bug nor adds a feature |
+| `chore` | tooling, deps, housekeeping |
+
+Examples from this repo: `fix(dark): hide education card separator lines in dark mode`,
+`feat(theme): 7-palette cycler, live swatch, per-palette dark mode`.
+
+---
+
+## Common tasks
+
+### Add a new page
+
+1. **Create the file** `public/<name>.html`. Copy an existing page (e.g.
+   [about.html](../public/about.html)) so you inherit the `<head>` boilerplate:
+   charset/viewport, Open Graph + Twitter meta, `canonical`, favicon,
+   `theme-color`, the stylesheet link, the dark-mode IIFE, and `theme-config.js`.
+2. Put the real content inside a single `<main><section>…</section></main>` —
+   the aggregate loader extracts exactly this.
+3. **Add a Render rewrite** in [render.yml](../render.yml):
+
+   ```yaml
+   - { type: rewrite, source: /<name>, destination: /<name>.html }
+   ```
+
+4. **Link it** from the navbar (`.nav-links`) and footer on the other pages,
+   using a root-relative href: `<a href="/<name>">Name</a>`.
+5. If it should appear in search results, add it to
+   [public/sitemap.xml](../public/sitemap.xml).
+6. To make it part of the **homepage** scroll, also add it to the `pages` array
+   in [aggregate.js](../public/src/js/aggregate.js) (see
+   [the note below](#edit-content-that-appears-on-the-homepage)).
+
+### Add a blog post
+
+Posts live as cards in [blog.html](../public/blog.html). Copy an existing
+`.blog-card` and edit it. The "Read more / Show less" behaviour is automatic for
+any card whose excerpt uses the `blog-excerpt` + `clamp` classes followed by a
+`.toggle-excerpt` button — both `main.js` and `aggregate.js` wire these up.
+
+### Add or change a colour palette
+
+Two files, in this order:
+
+1. **Colours** — in [theme.css](../public/src/css/theme.css), copy the
+   `[data-palette="alt"]` block, rename the selector (e.g. `[data-palette="ocean"]`),
+   and edit the tokens. You mainly need the `--*-rgb` channel triples; gradients
+   and tints derive from them. Add a matching
+   `[data-theme="dark"][data-palette="ocean"]` block for dark-mode backgrounds.
+2. **Behaviour** — in [theme-config.js](../public/src/js/theme-config.js), add an
+   entry to `window.SITE_THEME.palettes`:
+
+   ```js
+   { key: 'ocean', label: 'Ocean', attr: 'ocean' },   // attr = the data-palette value; null = :root
+   ```
+
+To **lock the site to one colour**, set `enablePaletteToggle: false`. To set the
+default for new visitors, change `defaultPalette`.
+
+### Edit content that appears on the homepage
+
+Remember the [dual-page model](ARCHITECTURE.md#the-dual-page-model): the homepage
+is assembled from the standalone pages at runtime. So:
+
+- Editing `about.html` updates **both** `/about` and the About section of `/`.
+- A **new** section won't show on the homepage until it's in the `pages` array in
+  [aggregate.js](../public/src/js/aggregate.js).
+- Content injected into the homepage is added **after** load — any new JS that
+  manipulates it must use event delegation or run inside `setupInteractions()`,
+  otherwise it won't see the injected markup.
+
+---
+
+## Pre-merge checklist
+
+- [ ] Page works **standalone** (`/about`) **and** on the **homepage** (`/#about`).
+- [ ] **Light and dark** mode both look right (toggle the 🌙 button).
+- [ ] **Both palettes** look right (click the colour swatch).
+- [ ] **Mobile** layout works (narrow the window; check the ☰ menu).
+- [ ] No new console errors; the network tab shows each section fetched `200`.
+- [ ] New colours use **CSS variables**, not hard-coded hex (so they theme correctly).
+- [ ] If you touched a global behaviour, you updated **both** `main.js` and
+      `aggregate.js`.
+- [ ] New/changed routes added to [render.yml](../render.yml) and, if public, to
+      [sitemap.xml](../public/sitemap.xml).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Documentation
+
+Developer documentation for the portfolio site. For setup, deployment, and the
+project overview, see the [root README](../README.md).
+
+| Doc | What's inside |
+| --- | --- |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | How the site works — the dual-page model, the homepage aggregate loader, the two-axis theming system, routing, the page lifecycle, and known quirks. |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | How to work on it — local dev, the branch/PR workflow, commit conventions, step-by-step guides (add a page, blog post, or palette), and a pre-merge checklist. |
+
+**New here?** Read [ARCHITECTURE.md](ARCHITECTURE.md) first to understand the
+dual-page / aggregate-loader model, then use [CONTRIBUTING.md](CONTRIBUTING.md)
+as a task reference.


### PR DESCRIPTION
Adds a `docs/` folder with developer documentation that goes deeper than the README.

## What's inside
- **docs/ARCHITECTURE.md** — explains the non-obvious design: the dual-page model (each page is both a standalone, crawlable file *and* a section stitched into the homepage), the `aggregate.js` loader, the two-axis theming system (`data-theme` + `data-palette`) with its pre-paint bootstrap, the page lifecycle, routing, and a 'known quirks' section (e.g. why a global behaviour change must touch both `main.js` and `aggregate.js`).
- **docs/CONTRIBUTING.md** — practical guide: local dev, the squash-merge PR workflow (incl. the diverged-history gotcha), conventional commits, step-by-step recipes for adding a page / blog post / palette, and a pre-merge checklist.
- **docs/README.md** — short index.
- **README.md** — adds `docs/` to the content tree and a Documentation section linking out.

No code changes — documentation only.