### PR TITLE
chore(ci): pin actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Bundle public/
         run: |
@@ -22,7 +22,7 @@ jobs:
           zip -r dist/portfolio-${{ github.ref_name }}.zip public/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.3.2
         with:
           name: Release ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
GitHub Actions is deprecating Node 20 runners on **June 16, 2026** (forced) and **September 16, 2026** (removed).

Pins both actions to their latest releases which already run on Node 24:
- `actions/checkout@v4` → `actions/checkout@v4.2.2`
- `softprops/action-gh-release@v2` → `softprops/action-gh-release@v2.3.2`