### PR TITLE
chore(ci): auto-sync deployment branch on push to main

### DIFF
--- a/.github/workflows/sync-deployment.yml
+++ b/.github/workflows/sync-deployment.yml
@@ -1,0 +1,22 @@
+name: Sync deployment branch
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0          # need full history to push
+
+      - name: Fast-forward deployment to main
+        run: |
+          git push origin HEAD:deployment --force


### PR DESCRIPTION
Render is configured to deploy from the `deployment` branch, not `main`. This workflow fast-forwards `deployment` to `main` automatically on every push, so Render always deploys the latest code without any manual intervention.