### PR TITLE
fix(mobile): keep hero CTA buttons on one row

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1140,8 +1140,13 @@ section {
     }
 
     .cta-buttons {
-        flex-direction: column;
-        align-items: center;
+        gap: 0.6rem;
+    }
+
+    .cta-button,
+    .cta-button-secondary {
+        padding: 0.75rem 1.25rem;
+        font-size: 0.875rem;
     }
 
     .about-content {


### PR DESCRIPTION
The mobile breakpoint was forcing `.cta-buttons` to `flex-direction: column`, stacking 'Discover My Work' and 'Download CV' vertically. Removed the column override and slightly tightened padding/font-size so both buttons fit side-by-side on small screens.