### PR TITLE
fix(mobile): show experience title on small screens

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1163,6 +1163,10 @@ section {
         margin-left: 40px !important;
     }
 
+    .timeline-title {
+        white-space: normal;
+    }
+
     .timeline-dot {
         left: 20px;
         transform: none;


### PR DESCRIPTION
`.timeline-title` had `white-space: nowrap` which clipped the entire text on narrow mobile cards. Added `white-space: normal` override in the mobile breakpoint so titles wrap instead of disappearing.