### PR TITLE
docs: update README + CONTRIBUTING with CI and auto-deploy info

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Deeper developer docs live in [`docs/`](docs/README.md):
 ## Content
 
     ├── README.md                      # Project overview, setup, deploy, and domain setup
+    ├── .github/workflows/             # GitHub Actions CI
+    │  ├── release.yml                 # Creates a GitHub Release + zip on every v*.*.* tag
+    │  └── sync-deployment.yml         # Fast-forwards the `deployment` branch to main on every push
     ├── docs/                          # Developer documentation
     │  ├── README.md                   # Docs index
     │  ├── ARCHITECTURE.md             # How the site works (dual-page model, loader, theming)
@@ -188,8 +191,18 @@ To **add a palette**: copy a block in `theme.css` (e.g. `[data-palette="alt"]`),
 
 ## Deployment
 
-Deployed with Render using `render.yml` file.  
-You can feed your GitHub project directly there (make it public).
+Deployed on **Render** (Static Site) using `render.yml`. Render watches the
+`deployment` branch — not `main`. A GitHub Actions workflow
+(`.github/workflows/sync-deployment.yml`) automatically fast-forwards
+`deployment` to `main` on every push, so merging a PR triggers a Render
+deploy with no manual steps.
+
+```
+merge PR → main → sync-deployment.yml → deployment branch → Render auto-deploy
+```
+
+> If Render stops auto-deploying, check that the service is set to watch the
+> `deployment` branch (Render dashboard → Settings → Branch).
 
 ### Local
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -63,6 +63,10 @@ gh pr create --fill --base main                 # or pass --title/--body
 gh pr merge --squash --delete-branch
 ```
 
+Merging to `main` automatically triggers the `sync-deployment.yml` workflow,
+which fast-forwards the `deployment` branch so **Render deploys without any
+manual step**.
+
 > **Heads-up on squash merges.** Because PRs are squash-merged, a feature branch's
 > individual commits won't exist on `main`. If you keep working on an old branch
 > after its PR merged, git history diverges and GitHub reports phantom conflicts.


### PR DESCRIPTION
- **README**: fixes a stray `Dis` artifact; adds `.github/workflows/` to the content tree; expands the Deployment section to explain the `deployment` branch + `sync-deployment.yml` auto-sync model.
- **CONTRIBUTING**: adds a note that merging to `main` automatically triggers Render via the sync workflow — no manual deploy needed.