### PR TITLE
fix(mobile): fix experience title/company truncation on small screens

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1163,8 +1163,15 @@ section {
         margin-left: 40px !important;
     }
 
+    .timeline-header {
+        flex-direction: column;
+        gap: 0.4rem;
+    }
+
     .timeline-title {
         white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
     }
 
     .timeline-dot {


### PR DESCRIPTION
- `.timeline-title` had `overflow:hidden` still active — title was clipped to 'Data...' etc. Fixed with `overflow:visible`.
- `.timeline-header` flex row with large gap + date badge left `.timeline-info` too narrow, forcing 'CEA-Saclay' and 'Circassian DNA' to wrap one word per line. Fixed by stacking the header vertically on mobile.