### PR TITLE
fix(mobile): force hero CTA buttons onto one line

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1140,13 +1140,15 @@ section {
     }
 
     .cta-buttons {
-        gap: 0.6rem;
+        gap: 0.5rem;
+        flex-wrap: nowrap;
     }
 
     .cta-button,
     .cta-button-secondary {
-        padding: 0.75rem 1.25rem;
-        font-size: 0.875rem;
+        padding: 0.65rem 0.9rem;
+        font-size: 0.8rem;
+        white-space: nowrap;
     }
 
     .about-content {


### PR DESCRIPTION
The previous fix removed `flex-direction:column` but the buttons still wrapped due to `flex-wrap:wrap` on the container. Added `flex-wrap:nowrap` and reduced padding + font-size so both buttons always fit on one line.