### PR TITLE
fix(mobile): date badge above title, smaller body text in experience

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1167,13 +1167,22 @@ section {
 
     .timeline-header {
         flex-direction: column;
-        gap: 0.4rem;
+        gap: 0.3rem;
+    }
+
+    .timeline-date {
+        order: -1;   /* date badge first, then title, then company */
+        align-self: flex-start;
     }
 
     .timeline-title {
         white-space: normal;
         overflow: visible;
         text-overflow: clip;
+    }
+
+    .timeline-content p {
+        font-size: 0.875rem;
     }
 
     .timeline-dot {


### PR DESCRIPTION
- Date badge moved to top of the stacked header (`order:-1`) so it sits right above the title/company instead of below.
- Timeline body text reduced to `0.875rem` on mobile for better fit.